### PR TITLE
Show current game header link only when active game exists

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -8,6 +8,6 @@ import {GamePlayComponent} from "./game_play/game_play.component";
 export const routes: Routes = [
   {path: "", component: HomeComponent},
   {path: "games", component: GamesComponent},
-  {path: "games/:id", component: GameComponent},
   {path: "games/running", component: GamePlayComponent},
+  {path: "games/:id", component: GameComponent},
 ];

--- a/src/app/game/game.component.ts
+++ b/src/app/game/game.component.ts
@@ -21,7 +21,12 @@ export class GameComponent implements OnInit {
     ) {
   }
   ngOnInit(): void {
-    this.gameService.loadGame(Number(this.route.snapshot.paramMap.get('id')));
+    const gameId = Number(this.route.snapshot.paramMap.get('id'));
+    if (Number.isNaN(gameId)) {
+      return;
+    }
+
+    this.gameService.loadGame(gameId);
   }
 
   getGame() {

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -1,4 +1,13 @@
 <div class="scenario">
+  <div class="level-keys">
+    <label for="key-input">Ключ:</label>
+    <input id="key-input" type="text" [ngModel]="keyText" (ngModelChange)="onKeyTextChange($event)" (keyup.enter)="submitKey()" />
+    <button type="button" (click)="submitKey()">Отправить</button>
+    @if (keyResult) {
+      <p class="key-result">Результат: {{ keyResult }}</p>
+    }
+  </div>
+
   <h3 class="level-header">Уровень №{{ getCurrentHints().level_number! + 1 }}</h3>
   <p>начался {{toLocal(getCurrentHints().started_at)}}</p>
   <ul class="hints">

--- a/src/app/game_play/game_play.component.scss
+++ b/src/app/game_play/game_play.component.scss
@@ -23,7 +23,19 @@
 }
 
 .level-keys {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
 
+#key-input {
+  text-transform: uppercase;
+}
+
+.key-result {
+  margin-left: 8px;
 }
 .keys-log table, th, td {
   border: 1px solid;

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -1,23 +1,26 @@
 import {Component, OnInit} from '@angular/core';
-import {GamePlayService, CurrentHints} from "./game_play.service";
-import {ActivatedRoute} from "@angular/router";
+import {GamePlayService, CurrentHints, TypedKeyResult} from "./game_play.service";
 import {HttpAdapter} from "../http/http.adapter";
 import {HintPartComponent} from "../hint.part/hint.part.component";
 import {HintPart} from "../game/game.service";
+import {FormsModule} from "@angular/forms";
 
 @Component({
   selector: 'app-game-play',
   standalone: true,
   imports: [
-    HintPartComponent
+    HintPartComponent,
+    FormsModule,
   ],
   templateUrl: './game_play.component.html',
   styleUrl: './game_play.component.scss'
 })
 export class GamePlayComponent implements OnInit {
+  keyText: string = "";
+  keyResult: string | undefined;
+
   constructor(
     private gameService: GamePlayService,
-    private route: ActivatedRoute,
     private http: HttpAdapter,
     ) {
   }
@@ -38,6 +41,35 @@ export class GamePlayComponent implements OnInit {
 
   toLocal(dt: string): any {
     return new Date(Date.parse(dt)).toLocaleTimeString();
+  }
+
+  onKeyTextChange(text: string) {
+    this.keyText = text.toUpperCase();
+  }
+
+  submitKey() {
+    const key = this.keyText.trim();
+    if (!key) {
+      return;
+    }
+
+    this.gameService.submitKey(key).subscribe(result => {
+      this.keyResult = this.mapResult(result);
+      this.keyText = "";
+    });
+  }
+
+  private mapResult(result: TypedKeyResult): string {
+    if (result.is_duplicate && result.wrong) {
+      return "duplicate (and wrong)";
+    }
+    if (result.is_duplicate) {
+      return "duplicate (but ok)";
+    }
+    if (result.wrong) {
+      return "wrong";
+    }
+    return "ok";
   }
 
   protected readonly Object = Object;

--- a/src/app/game_play/game_play.service.ts
+++ b/src/app/game_play/game_play.service.ts
@@ -3,6 +3,7 @@ import {HttpAdapter} from "../http/http.adapter";
 import {HttpErrorResponse} from "@angular/common/http";
 import {MatSnackBar} from "@angular/material/snack-bar";
 import {TimeHint} from "../game/game.service";
+import {Observable, tap} from "rxjs";
 
 export class CurrentHints {
   constructor(
@@ -11,6 +12,29 @@ export class CurrentHints {
     public level_number: number,
     public started_at: string,
     public game_id: number,
+  ) {
+  }
+}
+
+export class KeyEffect {
+  constructor(
+    public id: string,
+    public hints_: any[],
+    public bonus_minutes: number,
+    public level_up: boolean,
+    public next_level: string,
+  ) {
+  }
+}
+
+export class TypedKeyResult {
+  constructor(
+    public text: string,
+    public is_duplicate: boolean,
+    public wrong: boolean,
+    public at: string,
+    public effects: KeyEffect[],
+    public game_finished: boolean,
   ) {
   }
 }
@@ -42,5 +66,16 @@ export class GamePlayService {
 
   getCurrentHints(): CurrentHints {
     return this.currentHints!;
+  }
+
+  submitKey(text: string): Observable<TypedKeyResult> {
+    return this.http.post<TypedKeyResult>(`/games/running/key`, {text}).pipe(
+      tap(result => {
+        if (result.effects?.some(effect => effect.level_up)) {
+          this.snackBar.open("Уровень пройден! Загружаем следующий уровень.", 'Закрыть', {duration: 3000});
+          this.loadHints();
+        }
+      }),
+    );
   }
 }

--- a/src/app/games/games.service.ts
+++ b/src/app/games/games.service.ts
@@ -31,7 +31,7 @@ export class ActiveGame {
     public author: GameAuthor,
     public name: string,
     public status: string,
-    public start_at: string,
+    public start_at: string | null,
     public number: number,
   ) {
   }

--- a/src/app/games/games.service.ts
+++ b/src/app/games/games.service.ts
@@ -1,5 +1,6 @@
 import {Injectable} from '@angular/core';
 import {HttpAdapter} from "../http/http.adapter";
+import {catchError, map, Observable, of, shareReplay} from "rxjs";
 
 export class Page<T> {
   constructor(public content: T[]) {
@@ -15,6 +16,27 @@ export class Game {
   }
 }
 
+export class GameAuthor {
+  constructor(
+    public id: number,
+    public can_be_author: boolean,
+    public name_mention: string,
+  ) {
+  }
+}
+
+export class ActiveGame {
+  constructor(
+    public id: number,
+    public author: GameAuthor,
+    public name: string,
+    public status: string,
+    public start_at: string,
+    public number: number,
+  ) {
+  }
+}
+
 @Injectable({
   providedIn: 'root'
 })
@@ -23,6 +45,7 @@ export class GamesService {
     return this._games;
   }
   private _games: Game[] | undefined
+  private activeGame$: Observable<ActiveGame | undefined> | undefined;
 
   constructor(private http: HttpAdapter) { }
 
@@ -30,5 +53,17 @@ export class GamesService {
     return this.http.get<Page<Game>>("/games").subscribe(r => {
       this._games = r.content;
     })
+  }
+
+  getActiveGame(): Observable<ActiveGame | undefined> {
+    if (!this.activeGame$) {
+      this.activeGame$ = this.http.get<ActiveGame>("/games/active").pipe(
+        map(game => game?.id !== undefined ? game : undefined),
+        catchError(() => of(undefined)),
+        shareReplay(1),
+      );
+    }
+
+    return this.activeGame$;
   }
 }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,5 +1,5 @@
 @if (hasActiveGame()) {
-  <div class="active-game-banner">Идёт игра: {{ activeGame?.name }}</div>
+  <div class="active-game-banner">{{ getBannerText() }}</div>
 }
 <header>
   <div class="logo">
@@ -8,7 +8,7 @@
   <nav>
     <ul>
       <li><a routerLink="games" routerLinkActive="active" ariaCurrentWhenActive="page" class="nav-link">Прошедшие игры</a></li>
-      @if (hasActiveGame()) {
+      @if (hasRunningGame()) {
         <li><a routerLink="games/running" routerLinkActive="active" ariaCurrentWhenActive="page" class="nav-link" >Текущая игра</a></li>
       }
     </ul>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,5 +1,25 @@
 @if (hasActiveGame()) {
-  <div class="active-game-banner">{{ getBannerText() }}</div>
+  <div class="active-game-banner">
+    @if (hasRunningGame()) {
+      Идёт игра: {{ activeGame?.name }}
+    }
+
+    @if (isGettingWaiversStatus()) {
+      в настоящее время игра {{ activeGame?.name }} собирает вейверы
+    }
+
+    @if (isFinishedStatus()) {
+      игра завершена, ждём публикацию результатов
+    }
+
+    @if (isOtherPreStartStatus()) {
+      игра {{ activeGame?.name }} ещё не началась
+    }
+
+    @if (countdown) {
+      , игра начнётся через {{ countdown.firstValue }} {{ countdownUnitLabel(countdown.firstUnit) }} {{ countdown.secondValue }} {{ countdownUnitLabel(countdown.secondUnit) }}
+    }
+  </div>
 }
 <header>
   <div class="logo">

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -1,3 +1,6 @@
+@if (hasActiveGame()) {
+  <div class="active-game-banner">Идёт игра: {{ activeGame?.name }}</div>
+}
 <header>
   <div class="logo">
     <a routerLink="" routerLinkActive="active" ariaCurrentWhenActive="page" class="home-link">Схватка</a>
@@ -5,7 +8,9 @@
   <nav>
     <ul>
       <li><a routerLink="games" routerLinkActive="active" ariaCurrentWhenActive="page" class="nav-link">Прошедшие игры</a></li>
-      <li><a routerLink="games/running" routerLinkActive="active" ariaCurrentWhenActive="page" class="nav-link" >Текущая игра</a></li>
+      @if (hasActiveGame()) {
+        <li><a routerLink="games/running" routerLinkActive="active" ariaCurrentWhenActive="page" class="nav-link" >Текущая игра</a></li>
+      }
     </ul>
   </nav>
   <div class="user-section">

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -16,6 +16,13 @@ header {
   align-items: center;
 }
 
+.active-game-banner {
+  background-color: #146627;
+  color: #fff;
+  font-size: 14px;
+  padding: 4px 10px;
+}
+
 .logo a {
   color: #fff;
   text-decoration: none;

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -5,6 +5,7 @@ import {AuthService} from "../auth/auth.service";
 import {UserService} from "../auth/user.service";
 import {RouterLink, RouterLinkActive} from "@angular/router";
 import {MatIcon} from "@angular/material/icon";
+import {ActiveGame, GamesService} from "../games/games.service";
 
 @Component({
   selector: 'app-header',
@@ -25,10 +26,13 @@ export class HeaderComponent implements OnInit {
   private window;
   private readonly tg;
   private readonly tgWa;
+  activeGame: ActiveGame | undefined;
+
   constructor(
     @Inject(DOCUMENT) private _document: any,
     private authService: AuthService,
     private userService: UserService,
+    private gamesService: GamesService,
   ) {
     this.window = this._document.defaultView;
     this.tg = this.window.Telegram;
@@ -53,6 +57,8 @@ export class HeaderComponent implements OnInit {
   }
 
   async ngOnInit() {
+    this.gamesService.getActiveGame().subscribe(game => this.activeGame = game);
+
     if (this.tgWa.initData) {
       console.debug("let's try to auth with webapp")
       this.authService.authenticateWebApp(this.tgWa)
@@ -71,6 +77,10 @@ export class HeaderComponent implements OnInit {
       console.debug("no webapp auth data, so try to use cookies if exists")
       await this.userService.loadMe();
     }
+  }
+
+  hasActiveGame() {
+    return this.activeGame !== undefined;
   }
 
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -99,7 +99,15 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   hasRunningGame() {
-    return this.activeGame?.status === "running";
+    if (!this.activeGame || this.isFinishedStatus()) {
+      return false;
+    }
+
+    if (this.activeGame.status === "running") {
+      return true;
+    }
+
+    return this.isStartTimeReached();
   }
 
   isGettingWaiversStatus() {
@@ -130,13 +138,40 @@ export class HeaderComponent implements OnInit, OnDestroy {
       return;
     }
 
+    if (this.isStartTimeReached()) {
+      this.reloadOnceAfterCountdown();
+      return;
+    }
+
     this.countdownInterval = window.setInterval(() => {
       this.countdown = this.getCountdown();
 
       if (!this.countdown) {
-        window.location.reload();
+        this.reloadOnceAfterCountdown();
       }
     }, 1000);
+  }
+
+  private isStartTimeReached(): boolean {
+    if (!this.activeGame?.start_at) {
+      return false;
+    }
+
+    return Date.parse(this.activeGame.start_at) <= Date.now();
+  }
+
+  private reloadOnceAfterCountdown() {
+    if (!this.activeGame?.start_at) {
+      return;
+    }
+
+    const reloadKey = `active-game-reload:${this.activeGame.id}:${this.activeGame.start_at}`;
+    if (this.window.sessionStorage.getItem(reloadKey) === "done") {
+      return;
+    }
+
+    this.window.sessionStorage.setItem(reloadKey, "done");
+    window.location.reload();
   }
 
   private getCountdown(): Countdown | undefined {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -7,6 +7,15 @@ import {RouterLink, RouterLinkActive} from "@angular/router";
 import {MatIcon} from "@angular/material/icon";
 import {ActiveGame, GamesService} from "../games/games.service";
 
+type CountdownUnit = "days" | "hours" | "minutes" | "seconds";
+
+interface Countdown {
+  firstValue: number;
+  firstUnit: CountdownUnit;
+  secondValue: number;
+  secondUnit: CountdownUnit;
+}
+
 @Component({
   selector: 'app-header',
   standalone: true,
@@ -28,7 +37,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   private readonly tgWa;
   private countdownInterval: number | undefined;
   activeGame: ActiveGame | undefined;
-  startInMessage: string = "";
+  countdown: Countdown | undefined;
 
   constructor(
     @Inject(DOCUMENT) private _document: any,
@@ -61,7 +70,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   async ngOnInit() {
     this.gamesService.getActiveGame().subscribe(game => {
       this.activeGame = game;
-      this.startInMessage = this.getStartInMessage();
+      this.countdown = this.getCountdown();
       this.setupCountdownTicker();
     });
 
@@ -93,26 +102,16 @@ export class HeaderComponent implements OnInit, OnDestroy {
     return this.activeGame?.status === "running";
   }
 
-  getBannerText() {
-    if (!this.activeGame) {
-      return "";
-    }
+  isGettingWaiversStatus() {
+    return this.activeGame?.status === "getting_waivers";
+  }
 
-    if (this.activeGame.status === "running") {
-      return `Идёт игра: ${this.activeGame.name}`;
-    }
+  isFinishedStatus() {
+    return this.activeGame?.status === "finished";
+  }
 
-    if (this.activeGame.status === "getting_waivers") {
-      return `в настоящее время игра ${this.activeGame.name} собирает вейверы${this.startInMessage}`;
-    }
-
-    if (this.activeGame.status === "finished") {
-      return "игра завершена, ждём публикацию результатов";
-    }
-
-    return this.startInMessage
-      ? `игра ${this.activeGame.name} ещё не началась${this.startInMessage}`
-      : `игра ${this.activeGame.name} ещё не началась`;
+  isOtherPreStartStatus() {
+    return !!this.activeGame && !this.hasRunningGame() && !this.isGettingWaiversStatus() && !this.isFinishedStatus();
   }
 
   ngOnDestroy() {
@@ -132,32 +131,69 @@ export class HeaderComponent implements OnInit, OnDestroy {
     }
 
     this.countdownInterval = window.setInterval(() => {
-      this.startInMessage = this.getStartInMessage();
+      this.countdown = this.getCountdown();
+
+      if (!this.countdown) {
+        window.location.reload();
+      }
     }, 1000);
   }
 
-  private getStartInMessage(): string {
+  private getCountdown(): Countdown | undefined {
     if (!this.activeGame?.start_at || this.activeGame.status === "running" || this.activeGame.status === "finished") {
-      return "";
+      return undefined;
     }
 
     const startAtMs = Date.parse(this.activeGame.start_at);
     const diffMs = Math.max(startAtMs - Date.now(), 0);
     const totalSeconds = Math.floor(diffMs / 1000);
+
+    if (totalSeconds <= 0) {
+      return undefined;
+    }
+
     const days = Math.floor(totalSeconds / 86400);
     const hours = Math.floor((totalSeconds % 86400) / 3600);
     const minutes = Math.floor((totalSeconds % 3600) / 60);
     const seconds = totalSeconds % 60;
 
     if (days > 0) {
-      return `, игра начнётся через ${days} дней ${hours} часов`;
+      return {
+        firstValue: days,
+        firstUnit: "days",
+        secondValue: hours,
+        secondUnit: "hours",
+      };
     }
 
     if (hours > 0) {
-      return `, игра начнётся через ${hours} часов ${minutes} минут`;
+      return {
+        firstValue: hours,
+        firstUnit: "hours",
+        secondValue: minutes,
+        secondUnit: "minutes",
+      };
     }
 
-    return `, игра начнётся через ${minutes} минут ${seconds} секунд`;
+    return {
+      firstValue: minutes,
+      firstUnit: "minutes",
+      secondValue: seconds,
+      secondUnit: "seconds",
+    };
+  }
+
+  countdownUnitLabel(unit: CountdownUnit): string {
+    switch (unit) {
+      case "days":
+        return "дней";
+      case "hours":
+        return "часов";
+      case "minutes":
+        return "минут";
+      case "seconds":
+        return "секунд";
+    }
   }
 
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,4 +1,4 @@
-import {Component, Inject, OnInit} from '@angular/core';
+import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
 import {DOCUMENT, NgClass, NgOptimizedImage, NgStyle} from "@angular/common";
 import {AuthComponent} from "../auth/auth.component";
 import {AuthService} from "../auth/auth.service";
@@ -22,11 +22,13 @@ import {ActiveGame, GamesService} from "../games/games.service";
   templateUrl: 'header.component.html',
   styleUrl: './header.component.scss',
 })
-export class HeaderComponent implements OnInit {
+export class HeaderComponent implements OnInit, OnDestroy {
   private window;
   private readonly tg;
   private readonly tgWa;
+  private countdownInterval: number | undefined;
   activeGame: ActiveGame | undefined;
+  startInMessage: string = "";
 
   constructor(
     @Inject(DOCUMENT) private _document: any,
@@ -57,7 +59,11 @@ export class HeaderComponent implements OnInit {
   }
 
   async ngOnInit() {
-    this.gamesService.getActiveGame().subscribe(game => this.activeGame = game);
+    this.gamesService.getActiveGame().subscribe(game => {
+      this.activeGame = game;
+      this.startInMessage = this.getStartInMessage();
+      this.setupCountdownTicker();
+    });
 
     if (this.tgWa.initData) {
       console.debug("let's try to auth with webapp")
@@ -81,6 +87,77 @@ export class HeaderComponent implements OnInit {
 
   hasActiveGame() {
     return this.activeGame !== undefined;
+  }
+
+  hasRunningGame() {
+    return this.activeGame?.status === "running";
+  }
+
+  getBannerText() {
+    if (!this.activeGame) {
+      return "";
+    }
+
+    if (this.activeGame.status === "running") {
+      return `Идёт игра: ${this.activeGame.name}`;
+    }
+
+    if (this.activeGame.status === "getting_waivers") {
+      return `в настоящее время игра ${this.activeGame.name} собирает вейверы${this.startInMessage}`;
+    }
+
+    if (this.activeGame.status === "finished") {
+      return "игра завершена, ждём публикацию результатов";
+    }
+
+    return this.startInMessage
+      ? `игра ${this.activeGame.name} ещё не началась${this.startInMessage}`
+      : `игра ${this.activeGame.name} ещё не началась`;
+  }
+
+  ngOnDestroy() {
+    if (this.countdownInterval) {
+      window.clearInterval(this.countdownInterval);
+    }
+  }
+
+  private setupCountdownTicker() {
+    if (this.countdownInterval) {
+      window.clearInterval(this.countdownInterval);
+      this.countdownInterval = undefined;
+    }
+
+    if (!this.activeGame?.start_at || this.activeGame.status === "running" || this.activeGame.status === "finished") {
+      return;
+    }
+
+    this.countdownInterval = window.setInterval(() => {
+      this.startInMessage = this.getStartInMessage();
+    }, 1000);
+  }
+
+  private getStartInMessage(): string {
+    if (!this.activeGame?.start_at || this.activeGame.status === "running" || this.activeGame.status === "finished") {
+      return "";
+    }
+
+    const startAtMs = Date.parse(this.activeGame.start_at);
+    const diffMs = Math.max(startAtMs - Date.now(), 0);
+    const totalSeconds = Math.floor(diffMs / 1000);
+    const days = Math.floor(totalSeconds / 86400);
+    const hours = Math.floor((totalSeconds % 86400) / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+
+    if (days > 0) {
+      return `, игра начнётся через ${days} дней ${hours} часов`;
+    }
+
+    if (hours > 0) {
+      return `, игра начнётся через ${hours} часов ${minutes} минут`;
+    }
+
+    return `, игра начнётся через ${minutes} минут ${seconds} секунд`;
   }
 
 }


### PR DESCRIPTION
### Motivation
- Only show the "Текущая игра" header link and display the active game name when the server reports an active game at `GET /games/active` to avoid dead navigation and unnecessary mobile traffic.
- Cache the active-game response in-memory to prevent repeated network requests from mobile clients.

### Description
- Added DTOs `GameAuthor` and `ActiveGame` and imported `rxjs` helpers in `src/app/games/games.service.ts` to model and fetch the active game.
- Implemented `getActiveGame()` in `GamesService` which calls `GET /games/active`, returns `undefined` on error or missing payload, and caches the result with `shareReplay(1)`.
- Updated `HeaderComponent` to subscribe to `getActiveGame()` on `ngOnInit()`, expose an `activeGame` field and `hasActiveGame()` helper, and injected `GamesService` in `src/app/header/header.component.ts`.
- Templating and styling changes in `src/app/header/header.component.html` and `.scss` to show a top banner with the active game name and to conditionally render the `Текущая игра` nav item only when an active game exists.

### Testing
- Ran `npm run build` which started an Angular build but failed due to environment network constraints: font inlining requested from Google Fonts returned HTTP 403, causing the build to abort; this failure is environmental and not specific to the implemented TypeScript changes.
- No automated unit tests were executed in this environment as part of this rollout (build attempt was the primary validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d56bf1c64c832a867d8e78ced3c82e)