### PR TITLE
Add profile page for password change

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import {GamesComponent} from "./games/games.component";
 import {HomeComponent} from "./home/home.component";
 import {GameComponent} from "./game/game.component";
 import {GamePlayComponent} from "./game_play/game_play.component";
+import {ProfileComponent} from "./profile/profile.component";
 
 
 export const routes: Routes = [
@@ -10,4 +11,5 @@ export const routes: Routes = [
   {path: "games", component: GamesComponent},
   {path: "games/running", component: GamePlayComponent},
   {path: "games/:id", component: GameComponent},
+  {path: "profile", component: ProfileComponent},
 ];

--- a/src/app/auth/user.service.ts
+++ b/src/app/auth/user.service.ts
@@ -1,6 +1,7 @@
 import {Injectable} from "@angular/core";
 import {HttpAdapter} from "../http/http.adapter";
 import {HttpErrorResponse} from "@angular/common/http";
+import {Observable} from "rxjs";
 
 export class UserData {
   db_id: number | undefined;
@@ -41,5 +42,9 @@ export class UserService {
 
   public clearUser() {
     this.me = undefined;
+  }
+
+  public changePassword(newPassword: string): Observable<void> {
+    return this.http.put<void>("/users/me/password", JSON.stringify(newPassword));
   }
 }

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -39,7 +39,7 @@
   <div class="user-section">
     @if (isAuthenticated()) {
       <div class="user-info">
-        <a href="#" class="avatar-link">
+        <a routerLink="/profile" class="avatar-link" (click)="onNavClick('/profile', $event)">
           <mat-icon svgIcon="account-circle"/>
           <span>{{ getMe()?.username }}</span>
         </a>
@@ -66,6 +66,9 @@
   </div>
   <a routerLink="/" class="mobile-link" (click)="onNavClick('/', $event)">Главная</a>
   <a routerLink="/games" class="mobile-link" (click)="onNavClick('/games', $event)">Прошедшие игры</a>
+  @if (isAuthenticated()) {
+    <a routerLink="/profile" class="mobile-link" (click)="onNavClick('/profile', $event)">Профиль</a>
+  }
   @if (hasRunningGame()) {
     <a routerLink="/games/running" class="mobile-link" (click)="onNavClick('/games/running', $event)">Текущая игра</a>
   }

--- a/src/app/http/http.adapter.ts
+++ b/src/app/http/http.adapter.ts
@@ -32,6 +32,17 @@ export class HttpAdapter {
     );
   }
 
+  put<T>(url: string, body: any): Observable<T> {
+    return this.http.put<T>(
+      this.config.apiUrl + url,
+      body,
+      {
+        withCredentials: true,
+        headers: {"Content-Type": "application/json"},
+      },
+    );
+  }
+
   getFileUrl(gameId: number, fileId: string): string {
     return `${this.config.apiUrl}/games/${gameId}/files/${fileId}`
   }

--- a/src/app/profile/profile.component.html
+++ b/src/app/profile/profile.component.html
@@ -1,0 +1,33 @@
+<section class="profile-page">
+  <h1>Профиль</h1>
+
+  @if (isAuthenticated) {
+    <p class="username">Пользователь: <strong>{{ username }}</strong></p>
+
+    <form class="password-form" (ngSubmit)="changePassword()">
+      <label for="newPassword">Новый пароль</label>
+      <input
+        id="newPassword"
+        name="newPassword"
+        type="password"
+        [(ngModel)]="newPassword"
+        autocomplete="new-password"
+      />
+
+      <label for="confirmPassword">Повторите пароль</label>
+      <input
+        id="confirmPassword"
+        name="confirmPassword"
+        type="password"
+        [(ngModel)]="confirmPassword"
+        autocomplete="new-password"
+      />
+
+      <button class="primary" type="submit" [disabled]="isSubmitting">
+        {{ isSubmitting ? 'Сохраняем...' : 'Изменить пароль' }}
+      </button>
+    </form>
+  } @else {
+    <p>Авторизуйтесь, чтобы изменить пароль.</p>
+  }
+</section>

--- a/src/app/profile/profile.component.scss
+++ b/src/app/profile/profile.component.scss
@@ -3,18 +3,21 @@
 .profile-page {
   max-width: 560px;
   margin: 0 auto;
-  background: #fff;
-  border: 1px solid #dbe4dd;
+  background: var(--tg-theme-bg-color, #ffffff);
+  color: var(--tg-theme-text-color, #1f2937);
+  border: 1px solid var(--tg-theme-hint-color, #dbe4dd);
   border-radius: 16px;
   padding: 1.25rem;
 }
 
 h1 {
   margin-top: 0;
+  color: inherit;
 }
 
 .username {
   margin-bottom: 1rem;
+  color: inherit;
 }
 
 .password-form {
@@ -25,14 +28,16 @@ h1 {
 
 label {
   font-size: 0.9rem;
-  color: #374151;
+  color: inherit;
 }
 
 input {
-  border: 1px solid #cbd5e1;
+  border: 1px solid var(--tg-theme-hint-color, #cbd5e1);
   border-radius: 10px;
   padding: 0.65rem 0.75rem;
   font-size: 0.95rem;
+  color: var(--tg-theme-text-color, #1f2937);
+  background: var(--tg-theme-secondary-bg-color, #ffffff);
 }
 
 .primary {
@@ -42,8 +47,8 @@ input {
   padding: 0.6rem 0.9rem;
   cursor: pointer;
   font-weight: 600;
-  background: $shvatka_green;
-  color: #fff;
+  background: var(--tg-theme-button-color, $shvatka_green);
+  color: var(--tg-theme-button-text-color, #ffffff);
 }
 
 .primary:disabled {

--- a/src/app/profile/profile.component.scss
+++ b/src/app/profile/profile.component.scss
@@ -1,0 +1,52 @@
+@import '../../styles.scss';
+
+.profile-page {
+  max-width: 560px;
+  margin: 0 auto;
+  background: #fff;
+  border: 1px solid #dbe4dd;
+  border-radius: 16px;
+  padding: 1.25rem;
+}
+
+h1 {
+  margin-top: 0;
+}
+
+.username {
+  margin-bottom: 1rem;
+}
+
+.password-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+label {
+  font-size: 0.9rem;
+  color: #374151;
+}
+
+input {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 0.65rem 0.75rem;
+  font-size: 0.95rem;
+}
+
+.primary {
+  margin-top: 0.75rem;
+  border: none;
+  border-radius: 10px;
+  padding: 0.6rem 0.9rem;
+  cursor: pointer;
+  font-weight: 600;
+  background: $shvatka_green;
+  color: #fff;
+}
+
+.primary:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}

--- a/src/app/profile/profile.component.ts
+++ b/src/app/profile/profile.component.ts
@@ -1,0 +1,71 @@
+import {Component, OnInit} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {NgIf} from '@angular/common';
+import {HttpErrorResponse} from '@angular/common/http';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {UserService} from '../auth/user.service';
+
+@Component({
+  selector: 'app-profile',
+  standalone: true,
+  imports: [FormsModule, NgIf],
+  templateUrl: './profile.component.html',
+  styleUrl: './profile.component.scss',
+})
+export class ProfileComponent implements OnInit {
+  newPassword = '';
+  confirmPassword = '';
+  isSubmitting = false;
+
+  constructor(
+    private userService: UserService,
+    private snackBar: MatSnackBar,
+  ) {
+  }
+
+  async ngOnInit() {
+    if (!this.userService.isUserLoaded()) {
+      await this.userService.loadMe();
+    }
+  }
+
+  get isAuthenticated(): boolean {
+    return this.userService.isUserLoaded();
+  }
+
+  get username(): string {
+    return this.userService.getMe()?.username || '';
+  }
+
+  changePassword() {
+    if (!this.newPassword || !this.confirmPassword) {
+      this.snackBar.open('Заполните оба поля пароля', 'OK');
+      return;
+    }
+
+    if (this.newPassword !== this.confirmPassword) {
+      this.snackBar.open('Пароли не совпадают', 'OK');
+      return;
+    }
+
+    this.isSubmitting = true;
+    this.userService.changePassword(this.newPassword)
+      .subscribe({
+        next: () => {
+          this.newPassword = '';
+          this.confirmPassword = '';
+          this.isSubmitting = false;
+          this.snackBar.open('Пароль успешно изменён', 'OK');
+        },
+        error: (err) => {
+          this.isSubmitting = false;
+          if (err instanceof HttpErrorResponse && err.status === 401) {
+            this.snackBar.open('Нужно войти в аккаунт', 'OK');
+            return;
+          }
+
+          this.snackBar.open('Не удалось изменить пароль', 'OK');
+        },
+      });
+  }
+}

--- a/src/tests/http/dev.http.adapter.ts
+++ b/src/tests/http/dev.http.adapter.ts
@@ -38,6 +38,14 @@ export class HttpAdapter {
     );
   }
 
+  put<T>(url: string, body: any): Observable<T> {
+    return this.http.put<T>(
+      this.config.apiUrl + url,
+      body,
+      this.getOptions(),
+    );
+  }
+
   getFileUrl(gameId: number, fileId: string): string {
     return `${this.config.apiUrl}/games/${gameId}/files/${fileId}`
   }


### PR DESCRIPTION
### Motivation
- Provide a simple user profile page so authenticated users can change their password via the existing backend API (`PUT /users/me/password`).
- Reuse existing HTTP and auth infrastructure so the UI action is authenticated and consistent with other requests.

### Description
- Add a standalone `ProfileComponent` with `profile.component.ts`, `profile.component.html`, and `profile.component.scss` that shows username and a password + confirm form and uses snackbars for user feedback. 
- Add `UserService.changePassword(newPassword: string)` that calls the backend with `PUT /users/me/password` and returns an `Observable<void>`. 
- Add `HttpAdapter.put<T>(url, body)` to support authenticated PUT requests and include `Content-Type: application/json` and `withCredentials`. 
- Register new route `{ path: "profile", component: ProfileComponent }` and update header links so authenticated users can open the profile from the desktop avatar and the mobile menu.
- The password body is sent as a JSON string (`JSON.stringify(newPassword)`) to match the expected request format used elsewhere.

### Testing
- Attempted `npm run build`; build progressed but failed in this environment due to external Google Fonts inlining returning HTTP 403 (external fetch issue), not related to the introduced code changes. 
- Confirmed repository changes and created a commit containing the new files and modifications (`git status`/commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da87a39c5c832ab26a7e3bccde5393)