### PR TITLE
Fix unauthenticated current-game UX and Telegram dark-mode readability

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -9,7 +9,8 @@
 }
 
 .app-content {
-  background: rgba(255, 255, 255, 0.9);
+  background: var(--tg-theme-secondary-bg-color, rgba(255, 255, 255, 0.9));
+  color: var(--tg-theme-text-color, #1f2937);
   border-radius: 16px;
   padding: clamp(1rem, 2vw, 1.5rem);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);

--- a/src/app/auth/auth.component.scss
+++ b/src/app/auth/auth.component.scss
@@ -11,7 +11,8 @@
 .login-form {
   width: min(440px, 100%);
   margin: 9vh auto 0;
-  background: #fff;
+  background: var(--tg-theme-secondary-bg-color, #fff);
+  color: var(--tg-theme-text-color, #111827);
   border: 1px solid #d1d5db;
   border-radius: 16px;
   padding: 1.25rem;
@@ -44,7 +45,7 @@ h3 {
 
 label {
   font-size: 0.9rem;
-  color: #374151;
+  color: var(--tg-theme-hint-color, #374151);
 }
 
 input {
@@ -52,6 +53,8 @@ input {
   border-radius: 10px;
   padding: 0.65rem 0.75rem;
   font-size: 0.95rem;
+  color: var(--tg-theme-text-color, #111827);
+  background: var(--tg-theme-bg-color, #fff);
 }
 
 .actions {

--- a/src/app/game/game.component.scss
+++ b/src/app/game/game.component.scss
@@ -41,7 +41,7 @@
 details {
   border: 1px solid #e5e7eb;
   border-radius: 12px;
-  background: #fff;
+  background: var(--tg-theme-secondary-bg-color, #fff);
   padding: 0.75rem;
   margin-bottom: 0.85rem;
 }

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -1,23 +1,33 @@
-<div class="scenario">
-  <div class="level-keys">
-    <label for="key-input">Ключ:</label>
-    <input id="key-input" type="text" [ngModel]="keyText" (ngModelChange)="onKeyTextChange($event)" (keyup.enter)="submitKey()" />
-    <button type="button" (click)="submitKey()">Отправить</button>
-    @if (keyResult) {
-      <p class="key-result">Результат: {{ keyResult }}</p>
-    }
-  </div>
+@if (isLoading()) {
+  <p class="status-message">Загрузка текущей игры...</p>
+}
 
-  <h3 class="level-header">Уровень №{{ getCurrentHints().level_number! + 1 }}</h3>
-  <p>начался {{toLocal(getCurrentHints().started_at)}}</p>
-  <ul class="hints">
-    @for (timeHint of getCurrentHints().hints; track timeHint.time) {
-      <li>
-        <h5 class="hint-header">Подсказка {{ timeHint.time }} мин.</h5>
-        @for (hint of timeHint.hint; track hint) {
-          <app-hint-part [hint]="hint" [fileUrl]="getFileUrl(hint)"></app-hint-part>
-        }
-      </li>
-    }
-  </ul>
-</div>
+@if (!isLoading() && isAuthRequired()) {
+  <p class="status-message">Для просмотра текущей игры нужно войти в аккаунт.</p>
+}
+
+@if (hasHints()) {
+  <div class="scenario">
+    <div class="level-keys">
+      <label for="key-input">Ключ:</label>
+      <input id="key-input" type="text" [ngModel]="keyText" (ngModelChange)="onKeyTextChange($event)" (keyup.enter)="submitKey()" />
+      <button type="button" (click)="submitKey()">Отправить</button>
+      @if (keyResult) {
+        <p class="key-result">Результат: {{ keyResult }}</p>
+      }
+    </div>
+
+    <h3 class="level-header">Уровень №{{ getCurrentHints()!.level_number! + 1 }}</h3>
+    <p>начался {{toLocal(getCurrentHints()!.started_at)}}</p>
+    <ul class="hints">
+      @for (timeHint of getCurrentHints()!.hints; track timeHint.time) {
+        <li>
+          <h5 class="hint-header">Подсказка {{ timeHint.time }} мин.</h5>
+          @for (hint of timeHint.hint; track hint) {
+            <app-hint-part [hint]="hint" [fileUrl]="getFileUrl(hint)"></app-hint-part>
+          }
+        </li>
+      }
+    </ul>
+  </div>
+}

--- a/src/app/game_play/game_play.component.scss
+++ b/src/app/game_play/game_play.component.scss
@@ -2,6 +2,10 @@
   text-align: center;
 }
 
+.status-message {
+  color: var(--tg-theme-hint-color, #6b7280);
+}
+
 .level-header {
   text-align: center;
 }
@@ -35,7 +39,7 @@ button {
   border-radius: 8px;
   padding: 0.45rem 0.8rem;
   background: #2f8f4e;
-  color: #fff;
+  color: var(--tg-theme-button-text-color, #fff);
 }
 
 .key-result {

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -28,15 +28,27 @@ export class GamePlayComponent implements OnInit {
     this.gameService.loadHints();
   }
 
-  getCurrentHints(): CurrentHints {
+  getCurrentHints(): CurrentHints | undefined {
     return this.gameService.getCurrentHints()
+  }
+
+  isLoading(): boolean {
+    return this.gameService.hintsLoading();
+  }
+
+  isAuthRequired(): boolean {
+    return this.gameService.isAuthRequired();
+  }
+
+  hasHints(): boolean {
+    return this.getCurrentHints() !== undefined;
   }
 
   getFileUrl(hint: HintPart) {
     if (hint.file_guid === undefined) {
       return undefined;
     }
-    return this.http.getFileUrl(this.getCurrentHints().game_id, hint.file_guid)
+    return this.http.getFileUrl(this.getCurrentHints()!.game_id, hint.file_guid)
   }
 
   toLocal(dt: string): any {
@@ -48,6 +60,10 @@ export class GamePlayComponent implements OnInit {
   }
 
   submitKey() {
+    if (!this.hasHints()) {
+      return;
+    }
+
     const key = this.keyText.trim();
     if (!key) {
       return;

--- a/src/app/game_play/game_play.service.ts
+++ b/src/app/game_play/game_play.service.ts
@@ -44,17 +44,26 @@ export class TypedKeyResult {
 })
 export class GamePlayService {
   private currentHints: CurrentHints | undefined;
+  private isHintsLoading = false;
+  private authRequired = false;
 
   constructor(private http: HttpAdapter, private snackBar: MatSnackBar) { }
 
   loadHints() {
+    this.isHintsLoading = true;
+    this.authRequired = false;
     this.http.get<CurrentHints>(`/games/running/level/current/hints`)
       .subscribe({
         next: h => {
           this.currentHints = h;
+          this.isHintsLoading = false;
         },
         error: error => {
+          this.isHintsLoading = false;
+          this.currentHints = undefined;
+
           if (error instanceof HttpErrorResponse && error.status === 401) {
+            this.authRequired = true;
             console.log("current hint 401 response: " + JSON.stringify(error));
             this.snackBar.open("Играть можно только авторизованным пользователям в составе команд", 'Закрыть', {duration: 3000});
           } else {
@@ -64,8 +73,16 @@ export class GamePlayService {
       })
   }
 
-  getCurrentHints(): CurrentHints {
-    return this.currentHints!;
+  getCurrentHints(): CurrentHints | undefined {
+    return this.currentHints;
+  }
+
+  hintsLoading(): boolean {
+    return this.isHintsLoading;
+  }
+
+  isAuthRequired(): boolean {
+    return this.authRequired;
   }
 
   submitKey(text: string): Observable<TypedKeyResult> {

--- a/src/app/games/games.component.scss
+++ b/src/app/games/games.component.scss
@@ -11,7 +11,7 @@
 .games-list-item {
   border: 1px solid #d1e7d7;
   border-radius: 12px;
-  background: #fff;
+  background: var(--tg-theme-secondary-bg-color, #fff);
   transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -133,7 +133,8 @@
     left: 0;
     height: 100dvh;
     width: min(86vw, 320px);
-    background: #fff;
+    background: var(--tg-theme-secondary-bg-color, #fff);
+    color: var(--tg-theme-text-color, #111827);
     z-index: 19;
     transform: translateX(-100%);
     transition: transform 0.25s ease;
@@ -154,7 +155,7 @@
 
   .mobile-link {
     text-decoration: none;
-    color: #1f2937;
+    color: var(--tg-theme-text-color, #1f2937);
     font-weight: 600;
     padding: 0.5rem 0;
     border-bottom: 1px solid #e5e7eb;
@@ -169,7 +170,7 @@
 
   .mobile-username {
     margin: 0;
-    color: #374151;
+    color: var(--tg-theme-text-color, #374151);
   }
 
   .mobile-auth .ghost-button {

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,10 +2,6 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 $shvatka_green: #2f8f4e;
 
-:root {
-  color-scheme: light;
-}
-
 .hidden {
   display: none;
 }
@@ -30,7 +26,7 @@ body {
   overflow-x: hidden;
 
   color: var(--tg-theme-text-color, #1f2937);
-  background: linear-gradient(180deg, #f1f6f3 0%, #eef2ff 100%);
+  background: var(--tg-theme-bg-color, linear-gradient(180deg, #f1f6f3 0%, #eef2ff 100%));
 }
 
 app-root {


### PR DESCRIPTION
### Motivation
- The current-game view could enter a broken, uninteractive state when the hints endpoint returned 401 for unauthenticated users and the UI showed an error without a stable fallback. 
- Several UI surfaces used hardcoded white backgrounds and text colors which made the Telegram miniapp dark-mode unreadable (white text on white background).

### Description
- Made `GamePlayService` track hints loading and auth-required state (`hintsLoading()` / `isAuthRequired()`) and return `getCurrentHints()` as optional so callers can handle missing data. 
- Updated `GamePlayComponent` to render explicit states: a loading message while hints load, an auth-required message when a 401 happened, and game content only when hints are present, and added a guard to prevent `submitKey()` when hints are unavailable. 
- Changed `game_play` template and styles to show status messages and use theme-aware colors (added `.status-message` and `--tg-theme-*` fallbacks). 
- Replaced hardcoded white backgrounds and some text colors with Telegram theme CSS variables across `src/styles.scss`, `src/app/app.component.scss`, `src/app/auth/auth.component.scss`, `src/app/games/games.component.scss`, `src/app/game/game.component.scss`, and `src/app/header/header.component.scss` and removed the forced `color-scheme: light` to improve dark-mode readability.

### Testing
- Ran TypeScript check with `npx tsc -p tsconfig.app.json --noEmit` which passed. 
- Ran `npm run build` which failed in this environment due to Angular attempting to inline external Google Fonts and receiving HTTP 403 (external fetch issue), so a full production build could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db2e59c14c832ab57271b819848419)