### PR TITLE
Improve key submission feedback and typed-keys spoiler

### DIFF
--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -12,10 +12,68 @@
       <label for="key-input">Ключ:</label>
       <input id="key-input" type="text" [ngModel]="keyText" (ngModelChange)="onKeyTextChange($event)" (keyup.enter)="submitKey()" />
       <button type="button" (click)="submitKey()">Отправить</button>
-      @if (keyResult) {
-        <p class="key-result">Результат: {{ keyResult }}</p>
-      }
     </div>
+
+    @if (keyResultData) {
+      <div class="key-result-panel"
+           [class.key-result-ok]="!keyResultData.wrong"
+           [class.key-result-wrong]="keyResultData.wrong"
+           [class.key-result-duplicate]="keyResultData.is_duplicate">
+        <p><strong>Результат:</strong> {{ keyResult }}</p>
+        <p><strong>Ключ:</strong> {{ keyResultData.text }}</p>
+        <p><strong>Эффекты:</strong></p>
+        <ul>
+          @if (keyResultData.effects.length === 0) {
+            <li>Нет эффектов</li>
+          }
+          @for (effect of keyResultData.effects; track effect.id) {
+            <li>
+              @for (tag of getEffectTags(effect); track tag) {
+                <span class="effect-tag">{{ tag }}</span>
+              }
+              @if (effect.hints_.length > 0) {
+                <ul>
+                  @for (hint of effect.hints_; track hint) {
+                    <li>{{ hint }}</li>
+                  }
+                </ul>
+              }
+            </li>
+          }
+        </ul>
+        <p><strong>Уровень пройден:</strong> {{ isLevelCompleted(keyResultData) ? 'Да' : 'Нет' }}</p>
+        <p><strong>Игра завершена:</strong> {{ keyResultData.game_finished ? 'Да' : 'Нет' }}</p>
+      </div>
+    }
+
+    @if (hasAnyTypedKeys()) {
+      <details class="typed-keys-spoiler">
+        <summary>Введённые ключи и эффекты</summary>
+        <ul>
+          @for (typedKey of getCurrentHints()!.typed_keys; track typedKey.at + typedKey.text) {
+            <li>
+              <strong>{{ typedKey.text }}</strong>
+              @if (typedKey.at) {
+                <span> ({{ toLocal(typedKey.at) }})</span>
+              }
+              @if (typedKey.wrong !== undefined) {
+                <span> — {{ typedKey.wrong ? 'ошибка' : 'ок' }}</span>
+              }
+              @if (typedKey.is_duplicate) {
+                <span> — duplicate</span>
+              }
+              @if (getTypedKeyEffects(typedKey).length > 0) {
+                <div class="typed-effects">
+                  @for (tag of getTypedKeyEffects(typedKey); track tag) {
+                    <span class="effect-tag">{{ tag }}</span>
+                  }
+                </div>
+              }
+            </li>
+          }
+        </ul>
+      </details>
+    }
 
     <h3 class="level-header">Уровень №{{ getCurrentHints()!.level_number! + 1 }}</h3>
     <p>начался {{toLocal(getCurrentHints()!.started_at)}}</p>

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -10,9 +10,27 @@
   <div class="scenario">
     <div class="level-keys">
       <label for="key-input">Ключ:</label>
-      <input id="key-input" type="text" [ngModel]="keyText" (ngModelChange)="onKeyTextChange($event)" (keyup.enter)="submitKey()" />
-      <button type="button" (click)="submitKey()">Отправить</button>
+      <input
+        id="key-input"
+        type="text"
+        [disabled]="isSubmitting"
+        [ngModel]="keyText"
+        (ngModelChange)="onKeyTextChange($event)"
+        (keyup.enter)="submitKey()"
+      />
+      <button type="button" [disabled]="isSubmitting" (click)="submitKey()">
+        @if (isSubmitting) {
+          <span class="button-loader"></span>
+          Отправка...
+        } @else {
+          Отправить
+        }
+      </button>
     </div>
+
+    @if (keySubmitError) {
+      <div class="key-submit-error">{{ keySubmitError }}</div>
+    }
 
     @if (keyResultData) {
       <div class="key-result-panel"
@@ -21,28 +39,34 @@
            [class.key-result-duplicate]="keyResultData.is_duplicate">
         <p><strong>Результат:</strong> {{ keyResult }}</p>
         <p><strong>Ключ:</strong> {{ keyResultData.text }}</p>
-        <p><strong>Эффекты:</strong></p>
-        <ul>
-          @if (keyResultData.effects.length === 0) {
-            <li>Нет эффектов</li>
-          }
-          @for (effect of keyResultData.effects; track effect.id) {
-            <li>
-              @for (tag of getEffectTags(effect); track tag) {
-                <span class="effect-tag">{{ tag }}</span>
-              }
-              @if (effect.hints_.length > 0) {
-                <ul>
-                  @for (hint of effect.hints_; track hint) {
-                    <li>{{ hint }}</li>
-                  }
-                </ul>
-              }
-            </li>
-          }
-        </ul>
-        <p><strong>Уровень пройден:</strong> {{ isLevelCompleted(keyResultData) ? 'Да' : 'Нет' }}</p>
-        <p><strong>Игра завершена:</strong> {{ keyResultData.game_finished ? 'Да' : 'Нет' }}</p>
+
+        @if (hasVisibleEffects(keyResultData)) {
+          <p><strong>Эффекты:</strong></p>
+          <ul>
+            @for (effect of getVisibleEffects(keyResultData); track effect.tags.join('-') + effect.hints.length) {
+              <li>
+                @for (tag of effect.tags; track tag) {
+                  <span class="effect-tag">{{ tag }}</span>
+                }
+                @if (effect.hints.length > 0) {
+                  <ul>
+                    @for (hint of effect.hints; track hint) {
+                      <li>{{ hint }}</li>
+                    }
+                  </ul>
+                }
+              </li>
+            }
+          </ul>
+        }
+
+        @if (isLevelCompleted(keyResultData)) {
+          <p><strong>Уровень пройден</strong></p>
+        }
+
+        @if (keyResultData.game_finished) {
+          <p><strong>Игра завершена</strong></p>
+        }
       </div>
     }
 
@@ -51,17 +75,17 @@
         <summary>Введённые ключи и эффекты</summary>
         <ul>
           @for (typedKey of getCurrentHints()!.typed_keys; track typedKey.at + typedKey.text) {
-            <li>
+            <li class="typed-key-entry"
+                [class.typed-key-ok]="typedKeyStatusClass(typedKey) === 'typed-key-ok'"
+                [class.typed-key-duplicate]="typedKeyStatusClass(typedKey) === 'typed-key-duplicate'"
+                [class.typed-key-wrong]="typedKeyStatusClass(typedKey) === 'typed-key-wrong'"
+                [class.typed-key-bad-duplicate]="typedKeyStatusClass(typedKey) === 'typed-key-bad-duplicate'">
+              <span class="typed-key-status">{{ typedKeyEmoji(typedKey) }} {{ typedKeyStatusText(typedKey) }}</span>
               <strong>{{ typedKey.text }}</strong>
               @if (typedKey.at) {
                 <span> ({{ toLocal(typedKey.at) }})</span>
               }
-              @if (typedKey.wrong !== undefined) {
-                <span> — {{ typedKey.wrong ? 'ошибка' : 'ок' }}</span>
-              }
-              @if (typedKey.is_duplicate) {
-                <span> — duplicate</span>
-              }
+
               @if (getTypedKeyEffects(typedKey).length > 0) {
                 <div class="typed-effects">
                   @for (tag of getTypedKeyEffects(typedKey); track tag) {

--- a/src/app/game_play/game_play.component.scss
+++ b/src/app/game_play/game_play.component.scss
@@ -42,8 +42,65 @@ button {
   color: var(--tg-theme-button-text-color, #fff);
 }
 
-.key-result {
-  margin-left: 8px;
+.key-result-panel {
+  margin: 0 0 16px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #94a3b8;
+}
+
+.key-result-panel p {
+  margin: 0.2rem 0;
+}
+
+.key-result-ok {
+  background: rgba(34, 197, 94, 0.2);
+}
+
+.key-result-wrong {
+  background: rgba(239, 68, 68, 0.2);
+}
+
+.key-result-duplicate {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    rgba(234, 179, 8, 0.5) 0,
+    rgba(234, 179, 8, 0.5) 14px,
+    rgba(34, 197, 94, 0.5) 14px,
+    rgba(34, 197, 94, 0.5) 28px
+  );
+}
+
+.key-result-duplicate.key-result-wrong {
+  background-image: repeating-linear-gradient(
+    -45deg,
+    rgba(234, 179, 8, 0.5) 0,
+    rgba(234, 179, 8, 0.5) 14px,
+    rgba(239, 68, 68, 0.5) 14px,
+    rgba(239, 68, 68, 0.5) 28px
+  );
+}
+
+.effect-tag {
+  display: inline-block;
+  margin: 0 4px 4px 0;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  font-size: 0.85rem;
+}
+
+.typed-keys-spoiler {
+  margin: 0 0 18px;
+}
+
+.typed-keys-spoiler summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.typed-effects {
+  margin-top: 4px;
 }
 
 .hints {

--- a/src/app/game_play/game_play.component.scss
+++ b/src/app/game_play/game_play.component.scss
@@ -9,6 +9,7 @@
 .level-header {
   text-align: center;
 }
+
 .level-header::before {
   display: inline-block;
   content: "";
@@ -40,13 +41,53 @@ button {
   padding: 0.45rem 0.8rem;
   background: #2f8f4e;
   color: var(--tg-theme-button-text-color, #fff);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+button:disabled,
+#key-input:disabled {
+  opacity: 0.75;
+  cursor: not-allowed;
+}
+
+.button-loader {
+  width: 12px;
+  height: 12px;
+  border: 2px solid rgba(255, 255, 255, 0.35);
+  border-top-color: #fff;
+  border-radius: 50%;
+  display: inline-block;
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.key-submit-error {
+  margin: 0 auto 12px;
+  max-width: 640px;
+  text-align: center;
+  color: #b91c1c;
 }
 
 .key-result-panel {
-  margin: 0 0 16px;
+  margin: 0 auto 16px;
   padding: 10px 12px;
   border-radius: 10px;
   border: 1px solid #94a3b8;
+  max-width: 640px;
+  text-align: center;
+}
+
+.key-result-panel ul {
+  margin: 0.4rem auto;
+  width: fit-content;
+  text-align: left;
 }
 
 .key-result-panel p {
@@ -63,21 +104,21 @@ button {
 
 .key-result-duplicate {
   background-image: repeating-linear-gradient(
-    -45deg,
-    rgba(234, 179, 8, 0.5) 0,
-    rgba(234, 179, 8, 0.5) 14px,
-    rgba(34, 197, 94, 0.5) 14px,
-    rgba(34, 197, 94, 0.5) 28px
+      -45deg,
+      rgba(234, 179, 8, 0.5) 0,
+      rgba(234, 179, 8, 0.5) 14px,
+      rgba(34, 197, 94, 0.5) 14px,
+      rgba(34, 197, 94, 0.5) 28px
   );
 }
 
 .key-result-duplicate.key-result-wrong {
   background-image: repeating-linear-gradient(
-    -45deg,
-    rgba(234, 179, 8, 0.5) 0,
-    rgba(234, 179, 8, 0.5) 14px,
-    rgba(239, 68, 68, 0.5) 14px,
-    rgba(239, 68, 68, 0.5) 28px
+      -45deg,
+      rgba(234, 179, 8, 0.5) 0,
+      rgba(234, 179, 8, 0.5) 14px,
+      rgba(239, 68, 68, 0.5) 14px,
+      rgba(239, 68, 68, 0.5) 28px
   );
 }
 
@@ -97,6 +138,28 @@ button {
 .typed-keys-spoiler summary {
   cursor: pointer;
   font-weight: 600;
+}
+
+.typed-key-entry {
+  margin-bottom: 8px;
+}
+
+.typed-key-status {
+  font-weight: 600;
+  margin-right: 6px;
+}
+
+.typed-key-ok .typed-key-status {
+  color: #15803d;
+}
+
+.typed-key-duplicate .typed-key-status {
+  color: #a16207;
+}
+
+.typed-key-wrong .typed-key-status,
+.typed-key-bad-duplicate .typed-key-status {
+  color: #b91c1c;
 }
 
 .typed-effects {

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -1,5 +1,5 @@
-import {Component, OnInit} from '@angular/core';
-import {GamePlayService, CurrentHints, TypedKeyResult} from "./game_play.service";
+import {Component, OnDestroy, OnInit} from '@angular/core';
+import {GamePlayService, CurrentHints, TypedKeyResult, KeyEffect} from "./game_play.service";
 import {HttpAdapter} from "../http/http.adapter";
 import {HintPartComponent} from "../hint.part/hint.part.component";
 import {HintPart} from "../domain/game.models";
@@ -15,9 +15,11 @@ import {FormsModule} from "@angular/forms";
   templateUrl: './game_play.component.html',
   styleUrl: './game_play.component.scss'
 })
-export class GamePlayComponent implements OnInit {
+export class GamePlayComponent implements OnInit, OnDestroy {
   keyText: string = "";
   keyResult: string | undefined;
+  keyResultData: TypedKeyResult | undefined;
+  private keyResultTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(
     private gameService: GamePlayService,
@@ -26,6 +28,10 @@ export class GamePlayComponent implements OnInit {
   }
   ngOnInit(): void {
     this.gameService.loadHints();
+  }
+
+  ngOnDestroy(): void {
+    this.clearResultTimer();
   }
 
   getCurrentHints(): CurrentHints | undefined {
@@ -71,8 +77,50 @@ export class GamePlayComponent implements OnInit {
 
     this.gameService.submitKey(key).subscribe(result => {
       this.keyResult = this.mapResult(result);
+      this.keyResultData = result;
+      this.startResultTimer();
       this.keyText = "";
     });
+  }
+
+  isLevelCompleted(result: TypedKeyResult): boolean {
+    return result.effects?.some(effect => effect.level_up) ?? false;
+  }
+
+  getEffectTags(effect: KeyEffect): string[] {
+    const tags: string[] = [];
+
+    if (effect.bonus_minutes) {
+      tags.push(`bonus +${effect.bonus_minutes} min`);
+    }
+    if (effect.level_up) {
+      tags.push('level up');
+    }
+    if (effect.next_level) {
+      tags.push(`next level: ${effect.next_level}`);
+    }
+
+    if (Array.isArray(effect.hints_) && effect.hints_.length > 0) {
+      tags.push(`bonus hints: ${effect.hints_.length}`);
+    }
+
+    return tags;
+  }
+
+  getTypedKeyEffects(typedKey: any): string[] {
+    const effects = typedKey?.effects;
+    if (!Array.isArray(effects)) {
+      return [];
+    }
+
+    return effects
+      .flatMap((effect: KeyEffect) => this.getEffectTags(effect))
+      .filter((tag, idx, arr) => arr.indexOf(tag) === idx);
+  }
+
+  hasAnyTypedKeys(): boolean {
+    const typedKeys = this.getCurrentHints()?.typed_keys;
+    return Array.isArray(typedKeys) && typedKeys.length > 0;
   }
 
   private mapResult(result: TypedKeyResult): string {
@@ -86,6 +134,21 @@ export class GamePlayComponent implements OnInit {
       return "wrong";
     }
     return "ok";
+  }
+
+  private startResultTimer() {
+    this.clearResultTimer();
+    this.keyResultTimer = setTimeout(() => {
+      this.keyResult = undefined;
+      this.keyResultData = undefined;
+    }, 60_000);
+  }
+
+  private clearResultTimer() {
+    if (this.keyResultTimer) {
+      clearTimeout(this.keyResultTimer);
+      this.keyResultTimer = undefined;
+    }
   }
 
   protected readonly Object = Object;

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -4,6 +4,7 @@ import {HttpAdapter} from "../http/http.adapter";
 import {HintPartComponent} from "../hint.part/hint.part.component";
 import {HintPart} from "../domain/game.models";
 import {FormsModule} from "@angular/forms";
+import {finalize} from "rxjs";
 
 @Component({
   selector: 'app-game-play',
@@ -19,6 +20,8 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   keyText: string = "";
   keyResult: string | undefined;
   keyResultData: TypedKeyResult | undefined;
+  keySubmitError: string | undefined;
+  isSubmitting = false;
   private keyResultTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(
@@ -26,6 +29,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     private http: HttpAdapter,
     ) {
   }
+
   ngOnInit(): void {
     this.gameService.loadHints();
   }
@@ -57,7 +61,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     return this.http.getFileUrl(this.getCurrentHints()!.game_id, hint.file_guid)
   }
 
-  toLocal(dt: string): any {
+  toLocal(dt: string): string {
     return new Date(Date.parse(dt)).toLocaleTimeString();
   }
 
@@ -66,7 +70,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   }
 
   submitKey() {
-    if (!this.hasHints()) {
+    if (!this.hasHints() || this.isSubmitting) {
       return;
     }
 
@@ -75,16 +79,45 @@ export class GamePlayComponent implements OnInit, OnDestroy {
       return;
     }
 
-    this.gameService.submitKey(key).subscribe(result => {
-      this.keyResult = this.mapResult(result);
-      this.keyResultData = result;
-      this.startResultTimer();
-      this.keyText = "";
-    });
+    this.isSubmitting = true;
+    this.keySubmitError = undefined;
+
+    this.gameService.submitKey(key)
+      .pipe(finalize(() => {
+        this.isSubmitting = false;
+      }))
+      .subscribe({
+        next: result => {
+          this.keyResult = this.mapResult(result);
+          this.keyResultData = result;
+          this.startResultTimer();
+          this.keyText = "";
+        },
+        error: () => {
+          this.keySubmitError = "Не удалось отправить ключ";
+        }
+      });
   }
 
   isLevelCompleted(result: TypedKeyResult): boolean {
     return result.effects?.some(effect => effect.level_up) ?? false;
+  }
+
+  hasVisibleEffects(result: TypedKeyResult): boolean {
+    return this.getVisibleEffects(result).length > 0;
+  }
+
+  getVisibleEffects(result: TypedKeyResult): Array<{tags: string[], hints: any[]}> {
+    if (!Array.isArray(result.effects)) {
+      return [];
+    }
+
+    return result.effects
+      .map(effect => ({
+        tags: this.getEffectTags(effect),
+        hints: Array.isArray(effect.hints_) ? effect.hints_ : [],
+      }))
+      .filter(effect => effect.tags.length > 0 || effect.hints.length > 0);
   }
 
   getEffectTags(effect: KeyEffect): string[] {
@@ -123,6 +156,45 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     return Array.isArray(typedKeys) && typedKeys.length > 0;
   }
 
+  typedKeyStatusClass(typedKey: any): string {
+    if (typedKey?.wrong && typedKey?.is_duplicate) {
+      return 'typed-key-bad-duplicate';
+    }
+    if (typedKey?.wrong) {
+      return 'typed-key-wrong';
+    }
+    if (typedKey?.is_duplicate) {
+      return 'typed-key-duplicate';
+    }
+    return 'typed-key-ok';
+  }
+
+  typedKeyEmoji(typedKey: any): string {
+    if (typedKey?.wrong && typedKey?.is_duplicate) {
+      return '⚠️🔁';
+    }
+    if (typedKey?.wrong) {
+      return '❌';
+    }
+    if (typedKey?.is_duplicate) {
+      return '🔁';
+    }
+    return '✅';
+  }
+
+  typedKeyStatusText(typedKey: any): string {
+    if (typedKey?.wrong && typedKey?.is_duplicate) {
+      return 'дубликат + ошибка';
+    }
+    if (typedKey?.wrong) {
+      return 'ошибка';
+    }
+    if (typedKey?.is_duplicate) {
+      return 'дубликат';
+    }
+    return 'принят';
+  }
+
   private mapResult(result: TypedKeyResult): string {
     if (result.is_duplicate && result.wrong) {
       return "duplicate (and wrong)";
@@ -141,6 +213,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     this.keyResultTimer = setTimeout(() => {
       this.keyResult = undefined;
       this.keyResultData = undefined;
+      this.keySubmitError = undefined;
     }, 60_000);
   }
 
@@ -150,6 +223,4 @@ export class GamePlayComponent implements OnInit, OnDestroy {
       this.keyResultTimer = undefined;
     }
   }
-
-  protected readonly Object = Object;
 }


### PR DESCRIPTION
### Motivation
- Provide richer immediate feedback after submitting a key: show the exact key text returned by the backend, display all effects, and clearly indicate level and game completion state. 
- Make duplicate results visually distinct with diagonal striped backgrounds and use transparent green/red backgrounds for success/failure. 
- Expose a collapsible history of typed keys and their parsed effects below the input so players can inspect previous attempts and any bonus hints.

### Description
- Added result state handling to `GamePlayComponent`: new `keyResultData: TypedKeyResult`, a 1-minute auto-hide timer (`startResultTimer` / `clearResultTimer`), and `ngOnDestroy` cleanup. (`src/app/game_play/game_play.component.ts`).
- Implemented effect-parsing helpers `getEffectTags`, `getTypedKeyEffects`, `hasAnyTypedKeys`, and `isLevelCompleted` to render effect tags and derived labels from `KeyEffect` objects. (`src/app/game_play/game_play.component.ts`).
- Updated `submitKey()` to store the full typed-key response and start the auto-hide timer so the result panel is visible for 60 seconds. (`src/app/game_play/game_play.component.ts`).
- Template changes to show a result panel below the input with: result status, backend key text, list of effect tags, bonus hints list (if present), level-completed flag, and game-completed flag; and added a `details` spoiler with typed keys history and effect tags. (`src/app/game_play/game_play.component.html`).
- Styling updates: `.key-result-panel`, `.key-result-ok`, `.key-result-wrong`, `.key-result-duplicate` (diagonal repeating gradient for duplicates), `.effect-tag`, and typed-keys spoiler styles. (`src/app/game_play/game_play.component.scss`).

### Testing
- Ran `ng test` for `src/app/game_play/game_play.component.spec.ts`, which initially errored on a TypeScript conversion check and was fixed during the change; a later run failed in this environment due to missing `ChromeHeadless` binary so unit tests could not complete. (environment limitation).
- Attempted `ng build`; template/type issues were fixed, but a final build in this environment failed due to Google Fonts inlining returning HTTP 403, preventing a successful production build here. (environment limitation).
- No automated tests passed end-to-end in this execution environment due to the platform constraints described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd391cae70832aa06d3b1a7ca51e09)