### PR TITLE
Fix typed key log typing and wrong-key status rendering in gameplay

### DIFF
--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -51,7 +51,9 @@
                 @if (effect.hints.length > 0) {
                   <ul>
                     @for (hint of effect.hints; track hint) {
-                      <li>{{ hint }}</li>
+                      <li>
+                        <app-hint-part [hint]="hint" [fileUrl]="getFileUrl(hint)"></app-hint-part>
+                      </li>
                     }
                   </ul>
                 }

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -1,8 +1,8 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
-import {GamePlayService, CurrentHints, TypedKeyResult, KeyEffect} from "./game_play.service";
+import {GamePlayService, CurrentHints, TypedKeyResult, KeyEffect, TypedKeyLog} from "./game_play.service";
 import {HttpAdapter} from "../http/http.adapter";
 import {HintPartComponent} from "../hint.part/hint.part.component";
-import {HintPart} from "../domain/game.models";
+import {HintPart, KeyType} from "../domain/game.models";
 import {FormsModule} from "@angular/forms";
 import {finalize} from "rxjs";
 
@@ -140,7 +140,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     return tags;
   }
 
-  getTypedKeyEffects(typedKey: any): string[] {
+  getTypedKeyEffects(typedKey: TypedKeyLog): string[] {
     const effects = typedKey?.effects;
     if (!Array.isArray(effects)) {
       return [];
@@ -156,11 +156,12 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     return Array.isArray(typedKeys) && typedKeys.length > 0;
   }
 
-  typedKeyStatusClass(typedKey: any): string {
-    if (typedKey?.wrong && typedKey?.is_duplicate) {
+  typedKeyStatusClass(typedKey: TypedKeyLog): string {
+    const isWrong = this.isWrongTypedKey(typedKey);
+    if (isWrong && typedKey?.is_duplicate) {
       return 'typed-key-bad-duplicate';
     }
-    if (typedKey?.wrong) {
+    if (isWrong) {
       return 'typed-key-wrong';
     }
     if (typedKey?.is_duplicate) {
@@ -169,11 +170,12 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     return 'typed-key-ok';
   }
 
-  typedKeyEmoji(typedKey: any): string {
-    if (typedKey?.wrong && typedKey?.is_duplicate) {
+  typedKeyEmoji(typedKey: TypedKeyLog): string {
+    const isWrong = this.isWrongTypedKey(typedKey);
+    if (isWrong && typedKey?.is_duplicate) {
       return '⚠️🔁';
     }
-    if (typedKey?.wrong) {
+    if (isWrong) {
       return '❌';
     }
     if (typedKey?.is_duplicate) {
@@ -182,11 +184,12 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     return '✅';
   }
 
-  typedKeyStatusText(typedKey: any): string {
-    if (typedKey?.wrong && typedKey?.is_duplicate) {
+  typedKeyStatusText(typedKey: TypedKeyLog): string {
+    const isWrong = this.isWrongTypedKey(typedKey);
+    if (isWrong && typedKey?.is_duplicate) {
       return 'дубликат + ошибка';
     }
-    if (typedKey?.wrong) {
+    if (isWrong) {
       return 'ошибка';
     }
     if (typedKey?.is_duplicate) {
@@ -206,6 +209,10 @@ export class GamePlayComponent implements OnInit, OnDestroy {
       return "wrong";
     }
     return "ok";
+  }
+
+  private isWrongTypedKey(typedKey: TypedKeyLog): boolean {
+    return typedKey?.type_ === KeyType.wrong;
   }
 
   private startResultTimer() {

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -123,18 +123,21 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   getEffectTags(effect: KeyEffect): string[] {
     const tags: string[] = [];
 
-    if (effect.bonus_minutes) {
-      tags.push(`bonus +${effect.bonus_minutes} min`);
+    if (effect.bonus_minutes > 0) {
+      tags.push(`бонус ${effect.bonus_minutes} мин.`);
+    } else if (effect.bonus_minutes < 0) {
+      tags.push(`штраф ${-effect.bonus_minutes} мин.`);
     }
     if (effect.level_up) {
-      tags.push('level up');
-    }
-    if (effect.next_level) {
-      tags.push(`next level: ${effect.next_level}`);
+      if (effect.next_level) {
+        tags.push(`переход на ${effect.next_level}`);
+      } else {
+        tags.push('переход на следующий уровень');
+      }
     }
 
     if (Array.isArray(effect.hints_) && effect.hints_.length > 0) {
-      tags.push(`bonus hints: ${effect.hints_.length}`);
+      tags.push(`бонусные подсказки: ${effect.hints_.length}`);
     }
 
     return tags;
@@ -195,20 +198,20 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     if (typedKey?.is_duplicate) {
       return 'дубликат';
     }
-    return 'принят';
+    return 'корректный';
   }
 
   private mapResult(result: TypedKeyResult): string {
     if (result.is_duplicate && result.wrong) {
-      return "duplicate (and wrong)";
+      return "дубликат + ошибка";
     }
     if (result.is_duplicate) {
-      return "duplicate (but ok)";
+      return "дубликат";
     }
     if (result.wrong) {
-      return "wrong";
+      return "ошибка";
     }
-    return "ok";
+    return "корректный";
   }
 
   private isWrongTypedKey(typedKey: TypedKeyLog): boolean {

--- a/src/app/game_play/game_play.service.ts
+++ b/src/app/game_play/game_play.service.ts
@@ -2,13 +2,17 @@ import {Injectable} from '@angular/core';
 import {HttpAdapter} from "../http/http.adapter";
 import {HttpErrorResponse} from "@angular/common/http";
 import {MatSnackBar} from "@angular/material/snack-bar";
-import {TimeHint} from "../domain/game.models";
+import {KeyTime, TimeHint} from "../domain/game.models";
 import {Observable, tap} from "rxjs";
+
+export type TypedKeyLog = KeyTime & {
+  effects?: KeyEffect[];
+};
 
 export class CurrentHints {
   constructor(
     public hints: TimeHint[],
-    public typed_keys: any[],
+    public typed_keys: TypedKeyLog[],
     public level_number: number,
     public started_at: string,
     public game_id: number,

--- a/src/environments/environment.development.ts
+++ b/src/environments/environment.development.ts
@@ -1,6 +1,6 @@
 export const environment = {
   mainUrl: "http://localhost:4200",
-  apiUrl: "http://localhost:4200/api",
+  apiUrl: "http://192.168.1.13:4200/api",
   botUsername: "shvatkatestbot",
   baseHref: "/",
 };


### PR DESCRIPTION
### Motivation
- The gameplay hints payload used `typed_keys: any[]`, which lost type information for key logs and caused UI logic to misclassify wrong keys.
- Backend uses `type_` (string) to mark key kinds (e.g. `wrong`), while the UI previously checked a non-existent `wrong` boolean on log items.
- Effects attached to typed keys (`KeyEffect`) should be preserved on log entries for display in the UI.

### Description
- Added `TypedKeyLog` type as `KeyTime & { effects?: KeyEffect[] }` and imported `KeyTime` into `src/app/game_play/game_play.service.ts` to type `CurrentHints.typed_keys` as `TypedKeyLog[]`. 
- Exported `TypedKeyLog` and updated method signatures in `src/app/game_play/game_play.component.ts` to accept `TypedKeyLog` instead of `any` for typed-key helpers such as `getTypedKeyEffects`. 
- Fixed wrong-key detection by adding `isWrongTypedKey(typedKey: TypedKeyLog)` which checks `typedKey.type_ === KeyType.wrong` and used it in `typedKeyStatusClass`, `typedKeyEmoji`, and `typedKeyStatusText` so wrong keys are no longer shown as "ok". 

### Testing
- Ran `npm run build`, which reached Angular compilation but failed due to external font inlining returning HTTP 403 (Google Fonts), preventing completion of the build step. 
- TypeScript changes compiled up to the external fetch step and no type errors were reported prior to the font inlining failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4681b3c8832ab3b69e14680f0f12)