### PR TITLE
Adapt game level card to new scenario conditions model

### DIFF
--- a/src/app/domain/game.models.ts
+++ b/src/app/domain/game.models.ts
@@ -132,9 +132,9 @@ export class Effect {
 export class ScenarioCondition {
   constructor(
     public type: ScenarioConditionType,
-    public keys: string[] = [],
-    public effects: Effect[] = [],
-    public action_time: number | null = null,
+    public keys: string[] | undefined = undefined,
+    public effects: Effect[] | undefined = undefined,
+    public action_time: number | undefined = undefined,
   ) {
   }
 }

--- a/src/app/domain/game.models.ts
+++ b/src/app/domain/game.models.ts
@@ -112,12 +112,38 @@ export class TimeHint {
   }
 }
 
+export enum ScenarioConditionType {
+  winKey = "WIN_KEY",
+  effectsKey = "EFFECTS_KEY",
+  effectsTimer = "EFFECTS_TIMER",
+}
+
+export class Effect {
+  constructor(
+    public id: string,
+    public hints_: HintPart[] = [],
+    public bonus_minutes: number = 0,
+    public level_up: boolean = false,
+    public next_level: string | null = null,
+  ) {
+  }
+}
+
+export class ScenarioCondition {
+  constructor(
+    public type: ScenarioConditionType,
+    public keys: string[] = [],
+    public effects: Effect[] = [],
+    public action_time: number | null = null,
+  ) {
+  }
+}
+
 export class Scenario {
   constructor(
     public id: string,
     public time_hints: TimeHint[],
-    public keys: string[],
-    public bonus_keys: any[],
+    public conditions: ScenarioCondition[],
   ) {
   }
 }

--- a/src/app/domain/game.models.ts
+++ b/src/app/domain/game.models.ts
@@ -133,7 +133,7 @@ export class ScenarioCondition {
   constructor(
     public type: ScenarioConditionType,
     public keys: string[] | undefined = undefined,
-    public effects: Effect[] | undefined = undefined,
+    public effects: Effect[] | Effect | undefined = undefined,
     public action_time: number | undefined = undefined,
   ) {
   }

--- a/src/app/effects.part/effects.part.component.html
+++ b/src/app/effects.part/effects.part.component.html
@@ -1,13 +1,13 @@
 @if (getVisibleEffects().length > 0) {
   <ul class="effects-list">
-    @for (effect of getVisibleEffects(); track effect.id ?? $index) {
+    @for (effect of getVisibleEffects(); track $index) {
       <li>
-        @for (tag of getEffectTags(effect); track tag) {
+        @for (tag of getEffectTags(effect); track $index) {
           <span class="effect-tag">{{ tag }}</span>
         }
         @if (getEffectHints(effect).length > 0) {
           <ul>
-            @for (hint of getEffectHints(effect); track hint) {
+            @for (hint of getEffectHints(effect); track $index) {
               <li>
                 <app-hint-part [hint]="hint" [fileUrl]="getHintFileUrl(hint)"></app-hint-part>
               </li>

--- a/src/app/effects.part/effects.part.component.html
+++ b/src/app/effects.part/effects.part.component.html
@@ -1,0 +1,20 @@
+@if (getVisibleEffects().length > 0) {
+  <ul class="effects-list">
+    @for (effect of getVisibleEffects(); track effect.id ?? $index) {
+      <li>
+        @for (tag of getEffectTags(effect); track tag) {
+          <span class="effect-tag">{{ tag }}</span>
+        }
+        @if (getEffectHints(effect).length > 0) {
+          <ul>
+            @for (hint of getEffectHints(effect); track hint) {
+              <li>
+                <app-hint-part [hint]="hint" [fileUrl]="getHintFileUrl(hint)"></app-hint-part>
+              </li>
+            }
+          </ul>
+        }
+      </li>
+    }
+  </ul>
+}

--- a/src/app/effects.part/effects.part.component.scss
+++ b/src/app/effects.part/effects.part.component.scss
@@ -1,0 +1,13 @@
+.effects-list {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.effect-tag {
+  display: inline-block;
+  margin: 0 4px 4px 0;
+  padding: 0.15rem 0.45rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  font-size: 0.85rem;
+}

--- a/src/app/effects.part/effects.part.component.ts
+++ b/src/app/effects.part/effects.part.component.ts
@@ -1,0 +1,96 @@
+import {Component, Input} from '@angular/core';
+import {HintPart} from "../domain/game.models";
+import {HintPartComponent} from "../hint.part/hint.part.component";
+import {HttpAdapter} from "../http/http.adapter";
+
+export interface RenderableEffect {
+  id?: string;
+  hints_?: HintPart[];
+  hints?: HintPart[];
+  bonus_minutes?: number;
+  level_up?: boolean;
+  next_level?: string | null;
+}
+
+@Component({
+  selector: 'app-effects-part',
+  standalone: true,
+  imports: [
+    HintPartComponent,
+  ],
+  templateUrl: './effects.part.component.html',
+  styleUrl: './effects.part.component.scss'
+})
+export class EffectsPartComponent {
+  @Input() effects: RenderableEffect[] | RenderableEffect | undefined;
+  @Input() gameId: number | undefined;
+
+  constructor(private http: HttpAdapter) {
+  }
+
+  getVisibleEffects(): RenderableEffect[] {
+    const normalizedEffects = this.normalizeEffects(this.effects);
+
+    return normalizedEffects.filter(effect => {
+      return this.getEffectTags(effect).length > 0 || this.getEffectHints(effect).length > 0;
+    });
+  }
+
+  getEffectTags(effect: RenderableEffect): string[] {
+    const tags: string[] = [];
+    const bonusMinutes = typeof effect.bonus_minutes === 'number' ? effect.bonus_minutes : 0;
+
+    if (bonusMinutes > 0) {
+      tags.push(`бонус ${bonusMinutes} мин.`);
+    } else if (bonusMinutes < 0) {
+      tags.push(`штраф ${-bonusMinutes} мин.`);
+    }
+
+    if (effect.level_up) {
+      if (effect.next_level) {
+        tags.push(`переход на ${effect.next_level}`);
+      } else {
+        tags.push('переход на следующий уровень');
+      }
+    }
+
+    const hintsCount = this.getEffectHints(effect).length;
+    if (hintsCount > 0) {
+      tags.push(`бонусные подсказки: ${hintsCount}`);
+    }
+
+    return tags;
+  }
+
+  getEffectHints(effect: RenderableEffect): HintPart[] {
+    if (Array.isArray(effect.hints_)) {
+      return effect.hints_;
+    }
+
+    if (Array.isArray(effect.hints)) {
+      return effect.hints;
+    }
+
+    return [];
+  }
+
+  getHintFileUrl(hint: HintPart): string | undefined {
+    if (hint.file_guid === undefined || this.gameId === undefined) {
+      return undefined;
+    }
+
+    return this.http.getFileUrl(this.gameId, hint.file_guid);
+  }
+
+  private normalizeEffects(effects: RenderableEffect[] | RenderableEffect | undefined): RenderableEffect[] {
+    if (Array.isArray(effects)) {
+      return effects;
+    }
+
+    if (effects === undefined || effects === null) {
+      return [];
+    }
+
+    return [effects];
+  }
+}

--- a/src/app/game/game.component.html
+++ b/src/app/game/game.component.html
@@ -17,26 +17,24 @@
       @for (level of getGame()!.levels; track level.db_id) {
         <h3 class="level-header">Уровень №{{ level.number_in_game! + 1 }} ({{ level.name_id }})</h3>
         @if (getScenarioConditions(level).length > 0) {
-          <h4 class="level-keys-header">Условия:</h4>
-
           @if (getWinKeyCondition(level); as winCondition) {
-            <h5 class="hint-header">Ключ на прохождение:</h5>
+            <h4 class="level-keys-header">Ключи:</h4>
             <ul class="level-keys">
               @for (key of getConditionKeys(winCondition); track key) {
-                <li class="level-key">{{ key }}</li>
+                <li class="level-key">🔑 {{ key }}</li>
               }
             </ul>
           }
 
           @if (getEffectsKeyConditions(level).length > 0) {
-            <h5 class="hint-header">Ключи с эффектами:</h5>
+            <h4 class="level-keys-header">Ключи с эффектами:</h4>
             <ul class="level-keys">
               @for (condition of getEffectsKeyConditions(level); track 'effects-key:' + $index) {
                 <li class="level-key">
                   @if (getConditionKeys(condition).length > 0) {
                     <ul>
                       @for (key of getConditionKeys(condition); track key) {
-                        <li>{{ key }}</li>
+                        <li>🔑 {{ key }}</li>
                       }
                     </ul>
                   }
@@ -53,7 +51,7 @@
           }
 
           @if (getEffectsTimerConditions(level).length > 0) {
-            <h5 class="hint-header">Таймерные эффекты:</h5>
+            <h4 class="level-keys-header">Таймерные эффекты:</h4>
             <ul class="level-keys">
               @for (condition of getEffectsTimerConditions(level); track 'effects-timer:' + $index) {
                 <li class="level-key">
@@ -63,7 +61,7 @@
                   @if (getConditionKeys(condition).length > 0) {
                     <ul>
                       @for (key of getConditionKeys(condition); track key) {
-                        <li>{{ key }}</li>
+                        <li>🔑 {{ key }}</li>
                       }
                     </ul>
                   }

--- a/src/app/game/game.component.html
+++ b/src/app/game/game.component.html
@@ -39,11 +39,7 @@
                     </ul>
                   }
                   @if (getConditionEffectsSummary(condition).length > 0) {
-                    <ul>
-                      @for (effectSummary of getConditionEffectsSummary(condition); track effectSummary + ':' + $index) {
-                        <li>{{ effectSummary }}</li>
-                      }
-                    </ul>
+                    <app-effects-part [effects]="condition.effects" [gameId]="getGame()!.id"></app-effects-part>
                   }
                 </li>
               }
@@ -66,11 +62,7 @@
                     </ul>
                   }
                   @if (getConditionEffectsSummary(condition).length > 0) {
-                    <ul>
-                      @for (effectSummary of getConditionEffectsSummary(condition); track effectSummary + ':' + $index) {
-                        <li>{{ effectSummary }}</li>
-                      }
-                    </ul>
+                    <app-effects-part [effects]="condition.effects" [gameId]="getGame()!.id"></app-effects-part>
                   }
                 </li>
               }

--- a/src/app/game/game.component.html
+++ b/src/app/game/game.component.html
@@ -16,31 +16,69 @@
     <div class="scenario">
       @for (level of getGame()!.levels; track level.db_id) {
         <h3 class="level-header">Уровень №{{ level.number_in_game! + 1 }} ({{ level.name_id }})</h3>
-        <h4 class="level-keys-header">Условия:</h4>
-        <ul class="level-keys">
-          @for (condition of getScenarioConditions(level); track condition.type + ':' + $index) {
-            <li class="level-key">
-              <strong>{{ getConditionTitle(condition) }}</strong>
-              @if (condition.type === ScenarioConditionType.effectsTimer && condition.action_time !== null) {
-                <span> ({{ condition.action_time }} мин.)</span>
+        @if (getScenarioConditions(level).length > 0) {
+          <h4 class="level-keys-header">Условия:</h4>
+
+          @if (getWinKeyCondition(level); as winCondition) {
+            <h5 class="hint-header">Ключ на прохождение:</h5>
+            <ul class="level-keys">
+              @for (key of getConditionKeys(winCondition); track key) {
+                <li class="level-key">{{ key }}</li>
               }
-              @if (condition.keys.length > 0) {
-                <ul>
-                  @for (key of condition.keys; track key) {
-                    <li>{{ key }}</li>
-                  }
-                </ul>
-              }
-              @if (getConditionEffectsSummary(condition).length > 0) {
-                <ul>
-                  @for (effectSummary of getConditionEffectsSummary(condition); track effectSummary + ':' + $index) {
-                    <li>{{ effectSummary }}</li>
-                  }
-                </ul>
-              }
-            </li>
+            </ul>
           }
-        </ul>
+
+          @if (getEffectsKeyConditions(level).length > 0) {
+            <h5 class="hint-header">Ключи с эффектами:</h5>
+            <ul class="level-keys">
+              @for (condition of getEffectsKeyConditions(level); track 'effects-key:' + $index) {
+                <li class="level-key">
+                  @if (getConditionKeys(condition).length > 0) {
+                    <ul>
+                      @for (key of getConditionKeys(condition); track key) {
+                        <li>{{ key }}</li>
+                      }
+                    </ul>
+                  }
+                  @if (getConditionEffectsSummary(condition).length > 0) {
+                    <ul>
+                      @for (effectSummary of getConditionEffectsSummary(condition); track effectSummary + ':' + $index) {
+                        <li>{{ effectSummary }}</li>
+                      }
+                    </ul>
+                  }
+                </li>
+              }
+            </ul>
+          }
+
+          @if (getEffectsTimerConditions(level).length > 0) {
+            <h5 class="hint-header">Таймерные эффекты:</h5>
+            <ul class="level-keys">
+              @for (condition of getEffectsTimerConditions(level); track 'effects-timer:' + $index) {
+                <li class="level-key">
+                  @if (getTimerActionTime(condition); as actionTime) {
+                    <strong>{{ actionTime }} мин.</strong>
+                  }
+                  @if (getConditionKeys(condition).length > 0) {
+                    <ul>
+                      @for (key of getConditionKeys(condition); track key) {
+                        <li>{{ key }}</li>
+                      }
+                    </ul>
+                  }
+                  @if (getConditionEffectsSummary(condition).length > 0) {
+                    <ul>
+                      @for (effectSummary of getConditionEffectsSummary(condition); track effectSummary + ':' + $index) {
+                        <li>{{ effectSummary }}</li>
+                      }
+                    </ul>
+                  }
+                </li>
+              }
+            </ul>
+          }
+        }
         <h4 class="hints-header">Подсказки:</h4>
         <ul class="hints">
           @for (timeHint of level.scenario.time_hints; track timeHint.time) {

--- a/src/app/game/game.component.html
+++ b/src/app/game/game.component.html
@@ -16,10 +16,29 @@
     <div class="scenario">
       @for (level of getGame()!.levels; track level.db_id) {
         <h3 class="level-header">Уровень №{{ level.number_in_game! + 1 }} ({{ level.name_id }})</h3>
-        <h4 class="level-keys-header">Ключи:</h4>
+        <h4 class="level-keys-header">Условия:</h4>
         <ul class="level-keys">
-          @for (key of level.scenario.keys; track key) {
-            <li class="level-key">{{ key }}</li>
+          @for (condition of getScenarioConditions(level); track condition.type + ':' + $index) {
+            <li class="level-key">
+              <strong>{{ getConditionTitle(condition) }}</strong>
+              @if (condition.type === ScenarioConditionType.effectsTimer && condition.action_time !== null) {
+                <span> ({{ condition.action_time }} мин.)</span>
+              }
+              @if (condition.keys.length > 0) {
+                <ul>
+                  @for (key of condition.keys; track key) {
+                    <li>{{ key }}</li>
+                  }
+                </ul>
+              }
+              @if (getConditionEffectsSummary(condition).length > 0) {
+                <ul>
+                  @for (effectSummary of getConditionEffectsSummary(condition); track effectSummary + ':' + $index) {
+                    <li>{{ effectSummary }}</li>
+                  }
+                </ul>
+              }
+            </li>
           }
         </ul>
         <h4 class="hints-header">Подсказки:</h4>

--- a/src/app/game/game.component.ts
+++ b/src/app/game/game.component.ts
@@ -63,21 +63,25 @@ export class GameComponent implements OnInit, OnDestroy {
     return level.scenario.conditions ?? [];
   }
 
-  getConditionTitle(condition: ScenarioCondition): string {
-    switch (condition.type) {
-      case ScenarioConditionType.winKey:
-        return "Ключ на прохождение";
-      case ScenarioConditionType.effectsKey:
-        return "Ключ с эффектом";
-      case ScenarioConditionType.effectsTimer:
-        return "Таймерный эффект";
-      default:
-        return condition.type;
-    }
+  getWinKeyCondition(level: Level): ScenarioCondition | undefined {
+    return this.getScenarioConditions(level).find(condition => condition.type === ScenarioConditionType.winKey);
+  }
+
+  getEffectsKeyConditions(level: Level): ScenarioCondition[] {
+    return this.getScenarioConditions(level).filter(condition => condition.type === ScenarioConditionType.effectsKey);
+  }
+
+  getEffectsTimerConditions(level: Level): ScenarioCondition[] {
+    return this.getScenarioConditions(level).filter(condition => condition.type === ScenarioConditionType.effectsTimer);
+  }
+
+  getConditionKeys(condition: ScenarioCondition): string[] {
+    return Array.isArray(condition.keys) ? condition.keys : [];
   }
 
   getConditionEffectsSummary(condition: ScenarioCondition): string[] {
-    return condition.effects.flatMap(effect => {
+    const effects = Array.isArray(condition.effects) ? condition.effects : [];
+    return effects.flatMap(effect => {
       const tags: string[] = [];
       if (effect.bonus_minutes > 0) {
         tags.push(`бонус ${effect.bonus_minutes} мин.`);
@@ -95,6 +99,14 @@ export class GameComponent implements OnInit, OnDestroy {
 
       return tags;
     });
+  }
+
+  getTimerActionTime(condition: ScenarioCondition): number | undefined {
+    if (condition.type !== ScenarioConditionType.effectsTimer) {
+      return undefined;
+    }
+
+    return typeof condition.action_time === "number" ? condition.action_time : undefined;
   }
 
   isLoading(): boolean {

--- a/src/app/game/game.component.ts
+++ b/src/app/game/game.component.ts
@@ -6,6 +6,7 @@ import {HttpAdapter} from "../http/http.adapter";
 import {HintPartComponent} from "../hint.part/hint.part.component";
 import {Subscription} from "rxjs";
 import {GameLogPartComponent} from "../game_log.part/game_log.part.component";
+import {EffectsPartComponent} from "../effects.part/effects.part.component";
 
 @Component({
   selector: 'app-game',
@@ -13,6 +14,7 @@ import {GameLogPartComponent} from "../game_log.part/game_log.part.component";
   imports: [
     HintPartComponent,
     GameLogPartComponent,
+    EffectsPartComponent,
   ],
   templateUrl: './game.component.html',
   styleUrl: './game.component.scss'
@@ -80,7 +82,9 @@ export class GameComponent implements OnInit, OnDestroy {
   }
 
   getConditionEffectsSummary(condition: ScenarioCondition): string[] {
-    const effects = Array.isArray(condition.effects) ? condition.effects : [];
+    const effects = Array.isArray(condition.effects)
+      ? condition.effects
+      : (condition.effects ? [condition.effects] : []);
     return effects.flatMap(effect => {
       const tags: string[] = [];
       if (effect.bonus_minutes > 0) {

--- a/src/app/game/game.component.ts
+++ b/src/app/game/game.component.ts
@@ -1,6 +1,6 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {GameService} from "./game.service";
-import {FullGame, GameStat, HintPart, Keys, Level} from "../domain/game.models";
+import {FullGame, GameStat, HintPart, Keys, Level, ScenarioCondition, ScenarioConditionType} from "../domain/game.models";
 import {ActivatedRoute, ParamMap} from "@angular/router";
 import {HttpAdapter} from "../http/http.adapter";
 import {HintPartComponent} from "../hint.part/hint.part.component";
@@ -18,6 +18,7 @@ import {GameLogPartComponent} from "../game_log.part/game_log.part.component";
   styleUrl: './game.component.scss'
 })
 export class GameComponent implements OnInit, OnDestroy {
+  protected readonly ScenarioConditionType = ScenarioConditionType;
   private routeSubscription: Subscription | undefined;
 
   constructor(
@@ -56,6 +57,44 @@ export class GameComponent implements OnInit, OnDestroy {
 
   getLevels(): Level[] {
     return this.getGame()?.levels ?? [];
+  }
+
+  getScenarioConditions(level: Level): ScenarioCondition[] {
+    return level.scenario.conditions ?? [];
+  }
+
+  getConditionTitle(condition: ScenarioCondition): string {
+    switch (condition.type) {
+      case ScenarioConditionType.winKey:
+        return "Ключ на прохождение";
+      case ScenarioConditionType.effectsKey:
+        return "Ключ с эффектом";
+      case ScenarioConditionType.effectsTimer:
+        return "Таймерный эффект";
+      default:
+        return condition.type;
+    }
+  }
+
+  getConditionEffectsSummary(condition: ScenarioCondition): string[] {
+    return condition.effects.flatMap(effect => {
+      const tags: string[] = [];
+      if (effect.bonus_minutes > 0) {
+        tags.push(`бонус ${effect.bonus_minutes} мин.`);
+      } else if (effect.bonus_minutes < 0) {
+        tags.push(`штраф ${-effect.bonus_minutes} мин.`);
+      }
+
+      if (effect.level_up) {
+        if (effect.next_level) {
+          tags.push(`переход на ${effect.next_level}`);
+        } else {
+          tags.push("переход на следующий уровень");
+        }
+      }
+
+      return tags;
+    });
   }
 
   isLoading(): boolean {

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -40,26 +40,9 @@
         <p><strong>Результат:</strong> {{ keyResult }}</p>
         <p><strong>Ключ:</strong> {{ keyResultData.text }}</p>
 
-        @if (hasVisibleEffects(keyResultData)) {
+        @if (keyResultData.effects) {
           <p><strong>Эффекты:</strong></p>
-          <ul>
-            @for (effect of getVisibleEffects(keyResultData); track effect.tags.join('-') + effect.hints.length) {
-              <li>
-                @for (tag of effect.tags; track tag) {
-                  <span class="effect-tag">{{ tag }}</span>
-                }
-                @if (effect.hints.length > 0) {
-                  <ul>
-                    @for (hint of effect.hints; track hint) {
-                      <li>
-                        <app-hint-part [hint]="hint" [fileUrl]="getFileUrl(hint)"></app-hint-part>
-                      </li>
-                    }
-                  </ul>
-                }
-              </li>
-            }
-          </ul>
+          <app-effects-part [effects]="keyResultData.effects" [gameId]="getCurrentHints()?.game_id"></app-effects-part>
         }
 
         @if (isLevelCompleted(keyResultData)) {

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -18,6 +18,7 @@ import {FormsModule} from "@angular/forms";
 import {finalize, Subscription} from "rxjs";
 import {ActiveGame} from "../games/games.service";
 import {GameLogPartComponent} from "../game_log.part/game_log.part.component";
+import {EffectsPartComponent} from "../effects.part/effects.part.component";
 
 @Component({
   selector: 'app-game-play',
@@ -26,6 +27,7 @@ import {GameLogPartComponent} from "../game_log.part/game_log.part.component";
     HintPartComponent,
     FormsModule,
     GameLogPartComponent,
+    EffectsPartComponent,
   ],
   templateUrl: './game_play.component.html',
   styleUrl: './game_play.component.scss'
@@ -231,23 +233,6 @@ export class GamePlayComponent implements OnInit, OnDestroy {
 
   isLevelCompleted(result: TypedKeyResult): boolean {
     return result.effects?.some(effect => effect.level_up) ?? false;
-  }
-
-  hasVisibleEffects(result: TypedKeyResult): boolean {
-    return this.getVisibleEffects(result).length > 0;
-  }
-
-  getVisibleEffects(result: TypedKeyResult): Array<{tags: string[], hints: any[]}> {
-    if (!Array.isArray(result.effects)) {
-      return [];
-    }
-
-    return result.effects
-      .map(effect => ({
-        tags: this.getEffectTags(effect),
-        hints: Array.isArray(effect.hints_) ? effect.hints_ : [],
-      }))
-      .filter(effect => effect.tags.length > 0 || effect.hints.length > 0);
   }
 
   getEffectTags(effect: KeyEffect): string[] {


### PR DESCRIPTION
### Motivation
- The scenario shape was changed to replace flat `keys`/`bonus_keys` with structured `conditions` that can express `WIN_KEY`, `EFFECTS_KEY`, and `EFFECTS_TIMER` semantics.
- The UI must show the new condition objects (timer metadata, keys and effects) instead of the old simple key list.
- Make effect payloads (bonus minutes, level-up, next level and hints) available in the frontend model so the game card can summarise them.

### Description
- Added `ScenarioConditionType` enum, `Effect` and `ScenarioCondition` classes and replaced `Scenario` fields to `conditions` in `src/app/domain/game.models.ts`. 
- Updated `GameComponent` (`src/app/game/game.component.ts`) to import new types, expose `ScenarioConditionType` to the template, and add `getScenarioConditions`, `getConditionTitle` and `getConditionEffectsSummary` helpers. 
- Reworked the scenario template (`src/app/game/game.component.html`) to render `Условия` (conditions) instead of iterating `scenario.keys`, showing timer info for `EFFECTS_TIMER`, listing condition `keys`, and summarising effect tags (bonus/penalty minutes and level-up/next-level transitions). 
- Left existing hint rendering intact so `time_hints` and `HintPart` usage remain unchanged.

### Testing
- Ran `npm run build` which completed successfully (TypeScript compilation and Angular build passed) with existing bundle-budget and stylesheet-size warnings reported but not blocking the build.
- No additional automated unit tests were executed in this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51e746d7c832a9d3a89865acf729b)