### PR TITLE
Extract GameScenarioPart and add author-only scenario spoiler on current game

### DIFF
--- a/src/app/game/game.component.html
+++ b/src/app/game/game.component.html
@@ -13,75 +13,7 @@
   <h2 class="game-name">{{ getGame()!.name }}</h2>
   <details>
     <summary class="game-scn-spoiler">Сценарий игры</summary>
-    <div class="scenario">
-      @for (level of getGame()!.levels; track level.db_id) {
-        <h3 class="level-header">Уровень №{{ level.number_in_game! + 1 }} ({{ level.name_id }})</h3>
-        @if (getScenarioConditions(level).length > 0) {
-          @if (getWinKeyCondition(level); as winCondition) {
-            <h4 class="level-keys-header">Ключи:</h4>
-            <ul class="level-keys">
-              @for (key of getConditionKeys(winCondition); track key) {
-                <li class="level-key">🔑 {{ key }}</li>
-              }
-            </ul>
-          }
-
-          @if (getEffectsKeyConditions(level).length > 0) {
-            <h4 class="level-keys-header">Ключи с эффектами:</h4>
-            <ul class="level-keys">
-              @for (condition of getEffectsKeyConditions(level); track 'effects-key:' + $index) {
-                <li class="level-key">
-                  @if (getConditionKeys(condition).length > 0) {
-                    <ul>
-                      @for (key of getConditionKeys(condition); track key) {
-                        <li>🔑 {{ key }}</li>
-                      }
-                    </ul>
-                  }
-                  @if (getConditionEffectsSummary(condition).length > 0) {
-                    <app-effects-part [effects]="condition.effects" [gameId]="getGame()!.id"></app-effects-part>
-                  }
-                </li>
-              }
-            </ul>
-          }
-
-          @if (getEffectsTimerConditions(level).length > 0) {
-            <h4 class="level-keys-header">Таймерные эффекты:</h4>
-            <ul class="level-keys">
-              @for (condition of getEffectsTimerConditions(level); track 'effects-timer:' + $index) {
-                <li class="level-key">
-                  @if (getTimerActionTime(condition); as actionTime) {
-                    <strong>{{ actionTime }} мин.</strong>
-                  }
-                  @if (getConditionKeys(condition).length > 0) {
-                    <ul>
-                      @for (key of getConditionKeys(condition); track key) {
-                        <li>🔑 {{ key }}</li>
-                      }
-                    </ul>
-                  }
-                  @if (getConditionEffectsSummary(condition).length > 0) {
-                    <app-effects-part [effects]="condition.effects" [gameId]="getGame()!.id"></app-effects-part>
-                  }
-                </li>
-              }
-            </ul>
-          }
-        }
-        <h4 class="hints-header">Подсказки:</h4>
-        <ul class="hints">
-          @for (timeHint of level.scenario.time_hints; track timeHint.time) {
-            <li>
-              <h5 class="hint-header">Подсказка {{ timeHint.time }} мин.</h5>
-              @for (hint of timeHint.hint; track hint) {
-                <app-hint-part [hint]="hint" [fileUrl]="getFileUrl(hint)"></app-hint-part>
-              }
-            </li>
-          }
-        </ul>
-      }
-    </div>
+    <app-game-scenario-part [game]="getGame()!"></app-game-scenario-part>
   </details>
 
   <app-game-log-part [keys]="getKeys()" [stat]="getStat()" [levels]="getLevels()"></app-game-log-part>

--- a/src/app/game/game.component.ts
+++ b/src/app/game/game.component.ts
@@ -1,32 +1,27 @@
 import {Component, OnDestroy, OnInit} from '@angular/core';
 import {GameService} from "./game.service";
-import {FullGame, GameStat, HintPart, Keys, Level, ScenarioCondition, ScenarioConditionType} from "../domain/game.models";
+import {FullGame, GameStat, Keys, Level} from "../domain/game.models";
 import {ActivatedRoute, ParamMap} from "@angular/router";
-import {HttpAdapter} from "../http/http.adapter";
-import {HintPartComponent} from "../hint.part/hint.part.component";
 import {Subscription} from "rxjs";
 import {GameLogPartComponent} from "../game_log.part/game_log.part.component";
-import {EffectsPartComponent} from "../effects.part/effects.part.component";
+import {GameScenarioPartComponent} from "../game_scenario.part/game_scenario.part.component";
 
 @Component({
   selector: 'app-game',
   standalone: true,
   imports: [
-    HintPartComponent,
     GameLogPartComponent,
-    EffectsPartComponent,
+    GameScenarioPartComponent,
   ],
   templateUrl: './game.component.html',
   styleUrl: './game.component.scss'
 })
 export class GameComponent implements OnInit, OnDestroy {
-  protected readonly ScenarioConditionType = ScenarioConditionType;
   private routeSubscription: Subscription | undefined;
 
   constructor(
     private gameService: GameService,
     private route: ActivatedRoute,
-    private http: HttpAdapter,
   ) {
   }
 
@@ -61,72 +56,12 @@ export class GameComponent implements OnInit, OnDestroy {
     return this.getGame()?.levels ?? [];
   }
 
-  getScenarioConditions(level: Level): ScenarioCondition[] {
-    return level.scenario.conditions ?? [];
-  }
-
-  getWinKeyCondition(level: Level): ScenarioCondition | undefined {
-    return this.getScenarioConditions(level).find(condition => condition.type === ScenarioConditionType.winKey);
-  }
-
-  getEffectsKeyConditions(level: Level): ScenarioCondition[] {
-    return this.getScenarioConditions(level).filter(condition => condition.type === ScenarioConditionType.effectsKey);
-  }
-
-  getEffectsTimerConditions(level: Level): ScenarioCondition[] {
-    return this.getScenarioConditions(level).filter(condition => condition.type === ScenarioConditionType.effectsTimer);
-  }
-
-  getConditionKeys(condition: ScenarioCondition): string[] {
-    return Array.isArray(condition.keys) ? condition.keys : [];
-  }
-
-  getConditionEffectsSummary(condition: ScenarioCondition): string[] {
-    const effects = Array.isArray(condition.effects)
-      ? condition.effects
-      : (condition.effects ? [condition.effects] : []);
-    return effects.flatMap(effect => {
-      const tags: string[] = [];
-      if (effect.bonus_minutes > 0) {
-        tags.push(`бонус ${effect.bonus_minutes} мин.`);
-      } else if (effect.bonus_minutes < 0) {
-        tags.push(`штраф ${-effect.bonus_minutes} мин.`);
-      }
-
-      if (effect.level_up) {
-        if (effect.next_level) {
-          tags.push(`переход на ${effect.next_level}`);
-        } else {
-          tags.push("переход на следующий уровень");
-        }
-      }
-
-      return tags;
-    });
-  }
-
-  getTimerActionTime(condition: ScenarioCondition): number | undefined {
-    if (condition.type !== ScenarioConditionType.effectsTimer) {
-      return undefined;
-    }
-
-    return typeof condition.action_time === "number" ? condition.action_time : undefined;
-  }
-
   isLoading(): boolean {
     return this.gameService.isLoading();
   }
 
   hasLoadedData(): boolean {
     return this.gameService.hasLoadedCurrentGameData();
-  }
-
-  getFileUrl(hint: HintPart) {
-    if (hint.file_guid === undefined || this.getGame() === undefined) {
-      return undefined;
-    }
-
-    return this.http.getFileUrl(this.getGame()!.id, hint.file_guid);
   }
 
 }

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -171,3 +171,16 @@
     }
   </div>
 }
+
+@if (isCurrentUserGameAuthor()) {
+  <details class="author-scenario-spoiler">
+    <summary>Сценарий текущей игры</summary>
+    @if (isAuthorScenarioLoading) {
+      <p class="status-message">Загрузка сценария...</p>
+    } @else if (shouldShowAuthorScenario()) {
+      <app-game-scenario-part [game]="authorScenario!"></app-game-scenario-part>
+    } @else {
+      <p class="status-message">Не удалось загрузить сценарий.</p>
+    }
+  </details>
+}

--- a/src/app/game_play/game_play.component.scss
+++ b/src/app/game_play/game_play.component.scss
@@ -286,6 +286,10 @@ td {
   margin-top: 1rem;
 }
 
+.author-scenario-spoiler {
+  margin-top: 1rem;
+}
+
 .spy-panel-header {
   display: flex;
   justify-content: space-between;

--- a/src/app/game_play/game_play.component.scss
+++ b/src/app/game_play/game_play.component.scss
@@ -287,7 +287,18 @@ td {
 }
 
 .author-scenario-spoiler {
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: var(--app-surface);
+  padding: 0.75rem;
   margin-top: 1rem;
+  margin-bottom: 0.85rem;
+}
+
+.author-scenario-spoiler summary {
+  cursor: pointer;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
 }
 
 .spy-panel-header {

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -13,12 +13,14 @@ import {
 } from "./game_play.service";
 import {HttpAdapter} from "../http/http.adapter";
 import {HintPartComponent} from "../hint.part/hint.part.component";
-import {GameStat, HintPart, KeyType, Keys} from "../domain/game.models";
+import {FullGame, GameStat, HintPart, KeyType, Keys} from "../domain/game.models";
 import {FormsModule} from "@angular/forms";
 import {finalize, Subscription} from "rxjs";
 import {ActiveGame} from "../games/games.service";
 import {GameLogPartComponent} from "../game_log.part/game_log.part.component";
 import {EffectsPartComponent} from "../effects.part/effects.part.component";
+import {UserService} from "../auth/user.service";
+import {GameScenarioPartComponent} from "../game_scenario.part/game_scenario.part.component";
 
 @Component({
   selector: 'app-game-play',
@@ -28,6 +30,7 @@ import {EffectsPartComponent} from "../effects.part/effects.part.component";
     FormsModule,
     GameLogPartComponent,
     EffectsPartComponent,
+    GameScenarioPartComponent,
   ],
   templateUrl: './game_play.component.html',
   styleUrl: './game_play.component.scss'
@@ -40,6 +43,8 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   keyResultData: TypedKeyResult | undefined;
   keySubmitError: string | undefined;
   isSubmitting = false;
+  authorScenario: FullGame | undefined;
+  isAuthorScenarioLoading = false;
   private activeGameSubscription: Subscription | undefined;
   private countdownInterval: ReturnType<typeof setInterval> | undefined;
   private keyResultTimer: ReturnType<typeof setTimeout> | undefined;
@@ -47,6 +52,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   constructor(
     private gameService: GamePlayService,
     private http: HttpAdapter,
+    private userService: UserService,
     ) {
   }
 
@@ -54,6 +60,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     this.activeGameSubscription = this.gameService.getActiveGame(true).subscribe(game => {
       this.activeGame = game;
       this.startCountdownTicker();
+      this.loadAuthorScenario(game);
     });
     this.gameService.loadHints();
   }
@@ -124,6 +131,16 @@ export class GamePlayComponent implements OnInit, OnDestroy {
 
   getActiveGameName(): string {
     return this.activeGame?.name ?? "Текущая игра";
+  }
+
+  isCurrentUserGameAuthor(): boolean {
+    const myId = this.userService.getMe()?.db_id;
+    const authorId = this.activeGame?.author?.id;
+    return myId !== undefined && authorId !== undefined && myId === authorId;
+  }
+
+  shouldShowAuthorScenario(): boolean {
+    return this.isCurrentUserGameAuthor() && !!this.authorScenario;
   }
 
   getCountdownToStart(): string | undefined {
@@ -406,5 +423,28 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     }
 
     return `${minutes} мин. ${seconds} сек.`;
+  }
+
+  private loadAuthorScenario(game: ActiveGame | undefined) {
+    this.authorScenario = undefined;
+    this.isAuthorScenarioLoading = false;
+
+    if (!game || !this.isCurrentUserGameAuthor()) {
+      return;
+    }
+
+    this.isAuthorScenarioLoading = true;
+    this.http.get<FullGame>(`/games/${game.id}`)
+      .pipe(finalize(() => {
+        this.isAuthorScenarioLoading = false;
+      }))
+      .subscribe({
+        next: fullGame => {
+          this.authorScenario = fullGame;
+        },
+        error: () => {
+          this.authorScenario = undefined;
+        }
+      });
   }
 }

--- a/src/app/game_scenario.part/game_scenario.part.component.html
+++ b/src/app/game_scenario.part/game_scenario.part.component.html
@@ -1,25 +1,26 @@
 <div class="scenario">
   @for (level of game.levels; track level.db_id) {
-    <h3 class="level-header">Уровень №{{ level.number_in_game! + 1 }} ({{ level.name_id }})</h3>
+    <section class="level-card">
+      <h3 class="level-header">Уровень №{{ level.number_in_game! + 1 }} ({{ level.name_id }})</h3>
     @if (getScenarioConditions(level).length > 0) {
       @if (getWinKeyCondition(level); as winCondition) {
         <h4 class="level-keys-header">Ключи:</h4>
         <ul class="level-keys">
           @for (key of getConditionKeys(winCondition); track key) {
-            <li class="level-key">🔑 {{ key }}</li>
+            <li class="level-key">{{ key }}</li>
           }
         </ul>
       }
 
       @if (getEffectsKeyConditions(level).length > 0) {
         <h4 class="level-keys-header">Ключи с эффектами:</h4>
-        <ul class="level-keys">
+        <ul class="level-effects-list">
           @for (condition of getEffectsKeyConditions(level); track 'effects-key:' + $index) {
-            <li class="level-key">
+            <li class="level-effect-item">
               @if (getConditionKeys(condition).length > 0) {
-                <ul>
+                <ul class="level-keys nested-level-keys">
                   @for (key of getConditionKeys(condition); track key) {
-                    <li>🔑 {{ key }}</li>
+                    <li class="level-key">{{ key }}</li>
                   }
                 </ul>
               }
@@ -33,16 +34,16 @@
 
       @if (getEffectsTimerConditions(level).length > 0) {
         <h4 class="level-keys-header">Таймерные эффекты:</h4>
-        <ul class="level-keys">
+        <ul class="level-effects-list">
           @for (condition of getEffectsTimerConditions(level); track 'effects-timer:' + $index) {
-            <li class="level-key">
+            <li class="level-effect-item">
               @if (getTimerActionTime(condition); as actionTime) {
                 <strong>{{ actionTime }} мин.</strong>
               }
               @if (getConditionKeys(condition).length > 0) {
-                <ul>
+                <ul class="level-keys nested-level-keys">
                   @for (key of getConditionKeys(condition); track key) {
-                    <li>🔑 {{ key }}</li>
+                    <li class="level-key">{{ key }}</li>
                   }
                 </ul>
               }
@@ -57,7 +58,7 @@
     <h4 class="hints-header">Подсказки:</h4>
     <ul class="hints">
       @for (timeHint of level.scenario.time_hints; track timeHint.time) {
-        <li>
+        <li class="hint-item">
           <h5 class="hint-header">Подсказка {{ timeHint.time }} мин.</h5>
           @for (hint of timeHint.hint; track hint) {
             <app-hint-part [hint]="hint" [fileUrl]="getFileUrl(hint)"></app-hint-part>
@@ -65,5 +66,6 @@
         </li>
       }
     </ul>
+    </section>
   }
 </div>

--- a/src/app/game_scenario.part/game_scenario.part.component.html
+++ b/src/app/game_scenario.part/game_scenario.part.component.html
@@ -1,0 +1,69 @@
+<div class="scenario">
+  @for (level of game.levels; track level.db_id) {
+    <h3 class="level-header">Уровень №{{ level.number_in_game! + 1 }} ({{ level.name_id }})</h3>
+    @if (getScenarioConditions(level).length > 0) {
+      @if (getWinKeyCondition(level); as winCondition) {
+        <h4 class="level-keys-header">Ключи:</h4>
+        <ul class="level-keys">
+          @for (key of getConditionKeys(winCondition); track key) {
+            <li class="level-key">🔑 {{ key }}</li>
+          }
+        </ul>
+      }
+
+      @if (getEffectsKeyConditions(level).length > 0) {
+        <h4 class="level-keys-header">Ключи с эффектами:</h4>
+        <ul class="level-keys">
+          @for (condition of getEffectsKeyConditions(level); track 'effects-key:' + $index) {
+            <li class="level-key">
+              @if (getConditionKeys(condition).length > 0) {
+                <ul>
+                  @for (key of getConditionKeys(condition); track key) {
+                    <li>🔑 {{ key }}</li>
+                  }
+                </ul>
+              }
+              @if (getConditionEffectsSummary(condition).length > 0) {
+                <app-effects-part [effects]="condition.effects" [gameId]="game.id"></app-effects-part>
+              }
+            </li>
+          }
+        </ul>
+      }
+
+      @if (getEffectsTimerConditions(level).length > 0) {
+        <h4 class="level-keys-header">Таймерные эффекты:</h4>
+        <ul class="level-keys">
+          @for (condition of getEffectsTimerConditions(level); track 'effects-timer:' + $index) {
+            <li class="level-key">
+              @if (getTimerActionTime(condition); as actionTime) {
+                <strong>{{ actionTime }} мин.</strong>
+              }
+              @if (getConditionKeys(condition).length > 0) {
+                <ul>
+                  @for (key of getConditionKeys(condition); track key) {
+                    <li>🔑 {{ key }}</li>
+                  }
+                </ul>
+              }
+              @if (getConditionEffectsSummary(condition).length > 0) {
+                <app-effects-part [effects]="condition.effects" [gameId]="game.id"></app-effects-part>
+              }
+            </li>
+          }
+        </ul>
+      }
+    }
+    <h4 class="hints-header">Подсказки:</h4>
+    <ul class="hints">
+      @for (timeHint of level.scenario.time_hints; track timeHint.time) {
+        <li>
+          <h5 class="hint-header">Подсказка {{ timeHint.time }} мин.</h5>
+          @for (hint of timeHint.hint; track hint) {
+            <app-hint-part [hint]="hint" [fileUrl]="getFileUrl(hint)"></app-hint-part>
+          }
+        </li>
+      }
+    </ul>
+  }
+</div>

--- a/src/app/game_scenario.part/game_scenario.part.component.scss
+++ b/src/app/game_scenario.part/game_scenario.part.component.scss
@@ -1,0 +1,17 @@
+.level-header {
+  text-align: center;
+}
+
+.level-header::before {
+  display: inline-block;
+  content: "";
+  border-top: .1rem solid #9ca3af;
+  width: 100%;
+  margin: 0;
+  transform: translateY(-1rem);
+}
+
+.level-keys,
+.hints {
+  padding-left: 1.1rem;
+}

--- a/src/app/game_scenario.part/game_scenario.part.component.scss
+++ b/src/app/game_scenario.part/game_scenario.part.component.scss
@@ -1,5 +1,19 @@
+.scenario {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.level-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 10px;
+  padding: 0.55rem 0.6rem;
+  background: color-mix(in srgb, var(--app-surface) 92%, #ffffff);
+}
+
 .level-header {
   text-align: center;
+  margin: 0.15rem 0 0.55rem;
+  font-size: 1rem;
 }
 
 .level-header::before {
@@ -8,10 +22,63 @@
   border-top: .1rem solid #9ca3af;
   width: 100%;
   margin: 0;
-  transform: translateY(-1rem);
+  transform: translateY(-0.55rem);
 }
 
 .level-keys,
 .hints {
-  padding-left: 1.1rem;
+  margin: 0;
+  padding-left: 1.05rem;
+}
+
+.level-keys {
+  list-style: disc;
+}
+
+.level-key::marker {
+  content: "🔑 ";
+  font-size: 0.95rem;
+}
+
+.nested-level-keys {
+  margin-top: 0.35rem;
+}
+
+.level-keys-header,
+.hints-header {
+  margin: 0.45rem 0 0.35rem;
+  font-size: 0.92rem;
+}
+
+.level-effects-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.level-effect-item {
+  border: 1px solid #dbe3ed;
+  border-radius: 8px;
+  background: rgba(148, 163, 184, 0.08);
+  padding: 0.35rem 0.45rem;
+}
+
+.hints {
+  list-style: none;
+  padding: 0;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.hint-item {
+  list-style: none;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 8px;
+  padding: 0.35rem 0.45rem;
+}
+
+.hint-header {
+  margin: 0 0 0.3rem;
 }

--- a/src/app/game_scenario.part/game_scenario.part.component.ts
+++ b/src/app/game_scenario.part/game_scenario.part.component.ts
@@ -1,0 +1,85 @@
+import {Component, Input} from '@angular/core';
+import {FullGame, HintPart, Level, ScenarioCondition, ScenarioConditionType} from "../domain/game.models";
+import {HintPartComponent} from "../hint.part/hint.part.component";
+import {EffectsPartComponent} from "../effects.part/effects.part.component";
+import {HttpAdapter} from "../http/http.adapter";
+
+@Component({
+  selector: 'app-game-scenario-part',
+  standalone: true,
+  imports: [
+    HintPartComponent,
+    EffectsPartComponent,
+  ],
+  templateUrl: './game_scenario.part.component.html',
+  styleUrl: './game_scenario.part.component.scss'
+})
+export class GameScenarioPartComponent {
+  protected readonly ScenarioConditionType = ScenarioConditionType;
+
+  @Input({required: true}) game!: FullGame;
+
+  constructor(private http: HttpAdapter) {
+  }
+
+  getScenarioConditions(level: Level): ScenarioCondition[] {
+    return level.scenario.conditions ?? [];
+  }
+
+  getWinKeyCondition(level: Level): ScenarioCondition | undefined {
+    return this.getScenarioConditions(level).find(condition => condition.type === ScenarioConditionType.winKey);
+  }
+
+  getEffectsKeyConditions(level: Level): ScenarioCondition[] {
+    return this.getScenarioConditions(level).filter(condition => condition.type === ScenarioConditionType.effectsKey);
+  }
+
+  getEffectsTimerConditions(level: Level): ScenarioCondition[] {
+    return this.getScenarioConditions(level).filter(condition => condition.type === ScenarioConditionType.effectsTimer);
+  }
+
+  getConditionKeys(condition: ScenarioCondition): string[] {
+    return Array.isArray(condition.keys) ? condition.keys : [];
+  }
+
+  getConditionEffectsSummary(condition: ScenarioCondition): string[] {
+    const effects = Array.isArray(condition.effects)
+      ? condition.effects
+      : (condition.effects ? [condition.effects] : []);
+
+    return effects.flatMap(effect => {
+      const tags: string[] = [];
+      if (effect.bonus_minutes > 0) {
+        tags.push(`бонус ${effect.bonus_minutes} мин.`);
+      } else if (effect.bonus_minutes < 0) {
+        tags.push(`штраф ${-effect.bonus_minutes} мин.`);
+      }
+
+      if (effect.level_up) {
+        if (effect.next_level) {
+          tags.push(`переход на ${effect.next_level}`);
+        } else {
+          tags.push('переход на следующий уровень');
+        }
+      }
+
+      return tags;
+    });
+  }
+
+  getTimerActionTime(condition: ScenarioCondition): number | undefined {
+    if (condition.type !== ScenarioConditionType.effectsTimer) {
+      return undefined;
+    }
+
+    return typeof condition.action_time === 'number' ? condition.action_time : undefined;
+  }
+
+  getFileUrl(hint: HintPart) {
+    if (hint.file_guid === undefined) {
+      return undefined;
+    }
+
+    return this.http.getFileUrl(this.game.id, hint.file_guid);
+  }
+}


### PR DESCRIPTION
### Motivation
- Avoid duplicated scenario rendering logic and allow reusing the same scenario view across pages. 
- Show the full game scenario to the active game's author on the “Текущая игра” tab, following the same presentation as the game page.

### Description
- Added a new standalone component `GameScenarioPartComponent` that renders the full scenario (levels, keys/effects, timer effects, hints) without keys/stat blocks and uses `HttpAdapter` to resolve file URLs for hints (`src/app/game_scenario.part/*`).
- Replaced in-page scenario rendering in `GameComponent` with the new `app-game-scenario-part` to remove duplication and keep the original game page behavior (`src/app/game/game.component.*`).
- In `GamePlayComponent` added author detection via `UserService`, implemented `isCurrentUserGameAuthor()` and `loadAuthorScenario()` which fetches `/games/{id}` for the active game author, and render an author-only `<details>` spoiler after other content that shows the `app-game-scenario-part` when available (`src/app/game_play/game_play.component.*`).
- Added small styling for the author spoiler (`.author-scenario-spoiler`) and handled loading/error states for the author scenario fetch.

### Testing
- Ran `npm run build`, which completed successfully; Angular bundle/style budget warnings were reported but non-fatal.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e53ad4d9c4832aaeb5c8744822a09c)