### PR TITLE
Load Telegram scripts in background to avoid blocking page startup

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -67,6 +67,9 @@ export class AuthComponent implements AfterViewInit, OnInit {
     const element = this.script?.nativeElement;
     const script = document.createElement('script');
     script.src = 'https://telegram.org/js/telegram-widget.js?23';
+    script.async = true;
+    script.defer = true;
+    script.onerror = () => console.warn('Telegram widget script is unavailable');
     script.setAttribute('data-telegram-login', this.config.botUsername);
     script.setAttribute('data-size', 'large');
     script.setAttribute('data-request-access', 'write');

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -37,6 +37,7 @@ interface Countdown {
 export class HeaderComponent implements OnInit, OnDestroy {
   private window;
   private countdownInterval: number | undefined;
+  private telegramAuthAttempted = false;
   activeGame: ActiveGame | undefined;
   countdown: Countdown | undefined;
   isMobileMenuOpen = false;
@@ -117,24 +118,14 @@ export class HeaderComponent implements OnInit, OnDestroy {
       this.setupCountdownTicker();
     });
 
-    await this.telegramScriptService.loadWebAppSdk();
-    const tgWa = (this.window as any)?.Telegram?.WebApp;
-
-    if (tgWa?.initData) {
-      this.authService.authenticateWebApp(tgWa)
-        .subscribe({
-          next: async () => {
-            await this.userService.loadMe();
-            tgWa.ready();
-          },
-          error: async () => {
-            await this.userService.loadMe();
-          },
-        });
+    const sdkReadyWithinTimeout = await this.telegramScriptService.waitForWebAppSdk();
+    if (sdkReadyWithinTimeout && this.tryAuthenticateTelegramWebApp()) {
       return;
     }
 
     await this.userService.loadMe();
+    this.telegramScriptService.startLoadingWebAppSdk()
+      .then(() => this.tryAuthenticateTelegramWebApp());
   }
 
   hasActiveGame() {
@@ -173,6 +164,26 @@ export class HeaderComponent implements OnInit, OnDestroy {
     if (this.countdownInterval) {
       window.clearInterval(this.countdownInterval);
     }
+  }
+
+  private tryAuthenticateTelegramWebApp(): boolean {
+    const tgWa = (this.window as any)?.Telegram?.WebApp;
+    if (this.telegramAuthAttempted || !tgWa?.initData) {
+      return false;
+    }
+
+    this.telegramAuthAttempted = true;
+    this.authService.authenticateWebApp(tgWa)
+      .subscribe({
+        next: async () => {
+          await this.userService.loadMe();
+          tgWa.ready();
+        },
+        error: async () => {
+          await this.userService.loadMe();
+        },
+      });
+    return true;
   }
 
   private setupCountdownTicker() {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -8,6 +8,7 @@ import {Router, RouterLink, RouterLinkActive} from "@angular/router";
 import {MatIcon} from "@angular/material/icon";
 import {ActiveGame, GamesService} from "../games/games.service";
 import {THEME_MODES, ThemeMode, ThemeService} from "../theme/theme.service";
+import {TelegramScriptService} from "../telegram/telegram-script.service";
 
 type CountdownUnit = "days" | "hours" | "minutes" | "seconds";
 
@@ -35,8 +36,6 @@ interface Countdown {
 })
 export class HeaderComponent implements OnInit, OnDestroy {
   private window;
-  private readonly tg;
-  private readonly tgWa;
   private countdownInterval: number | undefined;
   activeGame: ActiveGame | undefined;
   countdown: Countdown | undefined;
@@ -51,10 +50,9 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private gamesService: GamesService,
     private router: Router,
     private themeService: ThemeService,
+    private telegramScriptService: TelegramScriptService,
   ) {
     this.window = this._document.defaultView;
-    this.tg = this.window?.Telegram;
-    this.tgWa = this.tg?.WebApp;
   }
 
   openLoginForm() {
@@ -119,20 +117,24 @@ export class HeaderComponent implements OnInit, OnDestroy {
       this.setupCountdownTicker();
     });
 
-    if (this.tgWa?.initData) {
-      this.authService.authenticateWebApp(this.tgWa)
+    await this.telegramScriptService.loadWebAppSdk();
+    const tgWa = (this.window as any)?.Telegram?.WebApp;
+
+    if (tgWa?.initData) {
+      this.authService.authenticateWebApp(tgWa)
         .subscribe({
           next: async () => {
             await this.userService.loadMe();
-            this.tgWa.ready();
+            tgWa.ready();
           },
           error: async () => {
             await this.userService.loadMe();
           },
         });
-    } else {
-      await this.userService.loadMe();
+      return;
     }
+
+    await this.userService.loadMe();
   }
 
   hasActiveGame() {

--- a/src/app/telegram/telegram-script.service.ts
+++ b/src/app/telegram/telegram-script.service.ts
@@ -8,11 +8,19 @@ export class TelegramScriptService {
 
   constructor(@Inject(DOCUMENT) private document: Document) {}
 
-  loadWebAppSdk(timeoutMs = 1500): Promise<boolean> {
-    return this.loadScript(this.webAppScriptUrl, timeoutMs);
+  startLoadingWebAppSdk(): Promise<boolean> {
+    return this.loadScript(this.webAppScriptUrl);
   }
 
-  private loadScript(src: string, timeoutMs: number): Promise<boolean> {
+  async waitForWebAppSdk(timeoutMs = 1500): Promise<boolean> {
+    const timeoutPromise = new Promise<boolean>((resolve) => {
+      window.setTimeout(() => resolve(false), timeoutMs);
+    });
+
+    return Promise.race([this.startLoadingWebAppSdk(), timeoutPromise]);
+  }
+
+  private loadScript(src: string): Promise<boolean> {
     const browserWindow = this.document.defaultView as (Window & {Telegram?: any}) | null;
     if (browserWindow?.Telegram?.WebApp) {
       return Promise.resolve(true);
@@ -39,22 +47,14 @@ export class TelegramScriptService {
         return;
       }
 
-      let isFinished = false;
-      const finalize = (value: boolean) => {
-        if (isFinished) {
-          return;
-        }
-
-        isFinished = true;
-        window.clearTimeout(timeoutHandle);
-        script.removeEventListener("load", handleLoad);
+      const handleLoad = () => {
         script.removeEventListener("error", handleError);
-        resolve(value);
+        resolve(!!browserWindow?.Telegram?.WebApp);
       };
-
-      const handleLoad = () => finalize(!!browserWindow?.Telegram?.WebApp);
-      const handleError = () => finalize(false);
-      const timeoutHandle = window.setTimeout(() => finalize(false), timeoutMs);
+      const handleError = () => {
+        script.removeEventListener("load", handleLoad);
+        resolve(false);
+      };
 
       script.addEventListener("load", handleLoad, {once: true});
       script.addEventListener("error", handleError, {once: true});

--- a/src/app/telegram/telegram-script.service.ts
+++ b/src/app/telegram/telegram-script.service.ts
@@ -1,0 +1,66 @@
+import {DOCUMENT} from "@angular/common";
+import {Inject, Injectable} from "@angular/core";
+
+@Injectable({providedIn: "root"})
+export class TelegramScriptService {
+  private readonly webAppScriptUrl = "https://telegram.org/js/telegram-web-app.js";
+  private readonly scriptLoads = new Map<string, Promise<boolean>>();
+
+  constructor(@Inject(DOCUMENT) private document: Document) {}
+
+  loadWebAppSdk(timeoutMs = 1500): Promise<boolean> {
+    return this.loadScript(this.webAppScriptUrl, timeoutMs);
+  }
+
+  private loadScript(src: string, timeoutMs: number): Promise<boolean> {
+    const browserWindow = this.document.defaultView as (Window & {Telegram?: any}) | null;
+    if (browserWindow?.Telegram?.WebApp) {
+      return Promise.resolve(true);
+    }
+
+    const existingPromise = this.scriptLoads.get(src);
+    if (existingPromise) {
+      return existingPromise;
+    }
+
+    const existingScript = this.document.querySelector(`script[src=\"${src}\"]`) as HTMLScriptElement | null;
+    const script = existingScript ?? this.document.createElement("script");
+
+    if (!existingScript) {
+      script.src = src;
+      script.async = true;
+      script.defer = true;
+      this.document.head.appendChild(script);
+    }
+
+    const loadPromise = new Promise<boolean>((resolve) => {
+      if (browserWindow?.Telegram?.WebApp) {
+        resolve(true);
+        return;
+      }
+
+      let isFinished = false;
+      const finalize = (value: boolean) => {
+        if (isFinished) {
+          return;
+        }
+
+        isFinished = true;
+        window.clearTimeout(timeoutHandle);
+        script.removeEventListener("load", handleLoad);
+        script.removeEventListener("error", handleError);
+        resolve(value);
+      };
+
+      const handleLoad = () => finalize(!!browserWindow?.Telegram?.WebApp);
+      const handleError = () => finalize(false);
+      const timeoutHandle = window.setTimeout(() => finalize(false), timeoutMs);
+
+      script.addEventListener("load", handleLoad, {once: true});
+      script.addEventListener("error", handleError, {once: true});
+    });
+
+    this.scriptLoads.set(src, loadPromise);
+    return loadPromise;
+  }
+}

--- a/src/app/theme/theme.service.ts
+++ b/src/app/theme/theme.service.ts
@@ -1,5 +1,6 @@
 import {DOCUMENT} from "@angular/common";
 import {Inject, Injectable, OnDestroy} from "@angular/core";
+import {TelegramScriptService} from "../telegram/telegram-script.service";
 
 export type ThemeMode = "system" | "light" | "dark";
 export const THEME_MODES: ThemeMode[] = ["system", "light", "dark"];
@@ -9,24 +10,33 @@ export class ThemeService implements OnDestroy {
   private readonly storageKey = "shvatka.theme.mode";
   private readonly mediaQuery: MediaQueryList | undefined;
   private readonly browserWindow: Window | null;
-  private readonly tgWebApp: any;
+  private tgWebApp: any;
+  private isTelegramThemeListenerBound = false;
   private currentMode: ThemeMode = "system";
 
-  constructor(@Inject(DOCUMENT) private document: Document) {
+  constructor(
+    @Inject(DOCUMENT) private document: Document,
+    private telegramScriptService: TelegramScriptService,
+  ) {
     this.browserWindow = this.document.defaultView;
     this.mediaQuery = this.browserWindow?.matchMedia?.("(prefers-color-scheme: dark)") ?? undefined;
-    this.tgWebApp = (this.browserWindow as any)?.Telegram?.WebApp;
+    this.tgWebApp = this.getTelegramWebApp();
 
     this.currentMode = this.readMode();
     this.applyMode(this.currentMode);
 
     this.mediaQuery?.addEventListener?.("change", this.handleSystemThemeChange);
-    this.tgWebApp?.onEvent?.("themeChanged", this.handleTelegramThemeChange);
+    this.bindTelegramThemeListener();
+    this.telegramScriptService.startLoadingWebAppSdk()
+      .then(() => this.bindTelegramThemeListener());
   }
 
   ngOnDestroy(): void {
     this.mediaQuery?.removeEventListener?.("change", this.handleSystemThemeChange);
-    this.tgWebApp?.offEvent?.("themeChanged", this.handleTelegramThemeChange);
+    if (this.isTelegramThemeListenerBound) {
+      this.tgWebApp?.offEvent?.("themeChanged", this.handleTelegramThemeChange);
+      this.isTelegramThemeListenerBound = false;
+    }
   }
 
   getMode(): ThemeMode {
@@ -83,6 +93,7 @@ export class ThemeService implements OnDestroy {
       return this.mediaQuery.matches ? "dark" : "light";
     }
 
+    this.tgWebApp = this.getTelegramWebApp();
     const tgScheme = this.isTelegramMiniApp() ? this.tgWebApp?.colorScheme : undefined;
     if (tgScheme === "dark" || tgScheme === "light") {
       return tgScheme;
@@ -92,6 +103,7 @@ export class ThemeService implements OnDestroy {
   }
 
   private isTelegramMiniApp(): boolean {
+    this.tgWebApp = this.getTelegramWebApp();
     return !!this.tgWebApp?.initData;
   }
 
@@ -105,5 +117,23 @@ export class ThemeService implements OnDestroy {
 
     this.tgWebApp.setBackgroundColor(backgroundColor);
     this.tgWebApp.setHeaderColor(headerColor);
+  }
+
+  private bindTelegramThemeListener(): void {
+    this.tgWebApp = this.getTelegramWebApp();
+    if (this.isTelegramThemeListenerBound || !this.tgWebApp?.onEvent) {
+      return;
+    }
+
+    this.tgWebApp.onEvent?.("themeChanged", this.handleTelegramThemeChange);
+    this.isTelegramThemeListenerBound = true;
+
+    if (this.currentMode === "system") {
+      this.applyMode(this.currentMode);
+    }
+  }
+
+  private getTelegramWebApp(): any {
+    return (this.browserWindow as any)?.Telegram?.WebApp;
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -6,7 +6,6 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
-  <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <!-- Load environment variables -->
   <script src="assets/env.js"></script>
 </head>


### PR DESCRIPTION
### Motivation
- The synchronous inclusion of Telegram SDK could block or delay page startup when the Telegram CDN is slow or unavailable, causing long loads or failed renders.
- Make Telegram integration optional and non-blocking so the app continues to initialize even if Telegram resources are unreachable.

### Description
- Removed the static `<script src="https://telegram.org/js/telegram-web-app.js">` from `src/index.html` to avoid blocking initial parsing.
- Added `TelegramScriptService` (`src/app/telegram/telegram-script.service.ts`) that injects the Telegram WebApp SDK dynamically with `async`/`defer` and resolves with a timeout fallback via `loadWebAppSdk(timeoutMs)`.
- Updated `HeaderComponent` (`src/app/header/header.component.ts`) to call `TelegramScriptService.loadWebAppSdk()` and only attempt WebApp authentication if the SDK/init data is present, otherwise it falls back to the normal `loadMe()` path.
- Made the Telegram login widget insertion in `AuthComponent` (`src/app/auth/auth.component.ts`) non-blocking by setting `async`/`defer` and added an `onerror` handler to log when the widget script cannot be fetched.

### Testing
- Ran `npm run build` and the build completed successfully (Angular reported bundle size warnings but no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e90dce2330832ab64f204418bc90e1)