### PR TITLE
Optimize Docker build caching for npm dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,12 @@
 FROM node:20.11.0 as build
 WORKDIR /usr/local/app
-COPY ./ /usr/local/app/
-RUN npm install
+
+# Install dependencies in a separate layer to maximize Docker build cache reuse.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy application source and build.
+COPY . .
 RUN npm run build
 
 
@@ -10,4 +15,3 @@ COPY --from=build /usr/local/app/dist/shvatka/browser /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["/bin/sh", "-c", "envsubst < /usr/share/nginx/html/assets/env.template.js > /usr/share/nginx/html/assets/env.js && exec nginx -g 'daemon off;'"]
-


### PR DESCRIPTION
### Motivation
- Reduce rebuild time and avoid re-running dependency installation when only HTML/CSS/JS source files change by separating dependency installation into its own Docker layer.
- Use lockfile-based install for deterministic, repeatable builds.

### Description
- Copy `package.json` and `package-lock.json` into the image before the rest of the source and run `npm ci` to install dependencies in a dedicated layer.
- Copy the full application source after dependency installation and run `npm run build` so source-only changes do not invalidate the dependency layer.
- Replace `npm install` with `npm ci` for deterministic, lockfile-driven installs.

### Testing
- Attempted to run `docker build --target build -t shvatka-ui:test .`, but the command could not run in this environment because Docker is not installed (`docker: command not found`).
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed1cf8c6a4832aa73a9153ff1f9f80)