### PR TITLE
Auto-refresh current hints and spy data aligned to level start

### DIFF
--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -48,6 +48,8 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   private activeGameSubscription: Subscription | undefined;
   private countdownInterval: ReturnType<typeof setInterval> | undefined;
   private keyResultTimer: ReturnType<typeof setTimeout> | undefined;
+  private autoRefreshTicker: ReturnType<typeof setInterval> | undefined;
+  private lastAutoRefreshMark: number | undefined;
 
   constructor(
     private gameService: GamePlayService,
@@ -63,12 +65,14 @@ export class GamePlayComponent implements OnInit, OnDestroy {
       this.loadAuthorScenario(game);
     });
     this.gameService.loadHints();
+    this.startAutoRefreshTicker();
   }
 
   ngOnDestroy(): void {
     this.clearResultTimer();
     this.activeGameSubscription?.unsubscribe();
     this.clearCountdownTicker();
+    this.clearAutoRefreshTicker();
   }
 
   getCurrentHints(): CurrentHints | undefined {
@@ -363,6 +367,60 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     if (this.keyResultTimer) {
       clearTimeout(this.keyResultTimer);
       this.keyResultTimer = undefined;
+    }
+  }
+
+
+  private startAutoRefreshTicker() {
+    this.clearAutoRefreshTicker();
+    this.autoRefreshTicker = setInterval(() => {
+      this.tryAutoRefreshCurrentGame();
+    }, 1000);
+  }
+
+  private clearAutoRefreshTicker() {
+    if (this.autoRefreshTicker) {
+      clearInterval(this.autoRefreshTicker);
+      this.autoRefreshTicker = undefined;
+    }
+
+    this.lastAutoRefreshMark = undefined;
+  }
+
+  private tryAutoRefreshCurrentGame() {
+    if (this.activeGame?.status !== "running") {
+      this.lastAutoRefreshMark = undefined;
+      return;
+    }
+
+    const hints = this.getCurrentHints();
+    if (!hints?.started_at) {
+      this.lastAutoRefreshMark = undefined;
+      return;
+    }
+
+    const startedAtMs = Date.parse(hints.started_at);
+    if (Number.isNaN(startedAtMs)) {
+      this.lastAutoRefreshMark = undefined;
+      return;
+    }
+
+    const elapsedSeconds = Math.floor((Date.now() - startedAtMs) / 1000);
+    if (elapsedSeconds < 61) {
+      this.lastAutoRefreshMark = undefined;
+      return;
+    }
+
+    const refreshMark = Math.floor((elapsedSeconds - 1) / 60);
+    if (this.lastAutoRefreshMark === refreshMark) {
+      return;
+    }
+
+    this.lastAutoRefreshMark = refreshMark;
+    this.gameService.loadHints();
+
+    if (this.activeGame?.id && this.canOpenSpyTab()) {
+      this.gameService.loadSpyData(this.activeGame.id, true);
     }
   }
 

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -50,6 +50,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   private keyResultTimer: ReturnType<typeof setTimeout> | undefined;
   private autoRefreshTicker: ReturnType<typeof setInterval> | undefined;
   private lastAutoRefreshMark: number | undefined;
+  private waiversStartReloadedGameId: number | undefined;
 
   constructor(
     private gameService: GamePlayService,
@@ -427,6 +428,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   private startCountdownTicker() {
     this.clearCountdownTicker();
     this.countdownToStart = this.buildCountdown();
+    this.reloadAfterWaiversStartReached();
 
     if (!this.activeGame?.start_at || this.isStartTimeReached()) {
       return;
@@ -434,10 +436,26 @@ export class GamePlayComponent implements OnInit, OnDestroy {
 
     this.countdownInterval = setInterval(() => {
       this.countdownToStart = this.buildCountdown();
+      this.reloadAfterWaiversStartReached();
       if (!this.countdownToStart) {
         this.clearCountdownTicker();
       }
     }, 1000);
+  }
+
+  private reloadAfterWaiversStartReached() {
+    if (
+      this.activeGame?.status !== "getting_waivers"
+      || !this.activeGame.id
+      || this.waiversStartReloadedGameId === this.activeGame.id
+      || !this.activeGame.start_at
+      || Date.parse(this.activeGame.start_at) > Date.now()
+    ) {
+      return;
+    }
+
+    this.waiversStartReloadedGameId = this.activeGame.id;
+    this.gameService.loadHints();
   }
 
   private clearCountdownTicker() {


### PR DESCRIPTION
### Motivation
- Current hints and spy data can change during a running game and the UI must repaint the whole current-game tab on a minute-aligned cadence starting from the current level `started_at` (61s, 121s, 181s, ...). 
- Spy view should refresh keys/stat on the same cadence when the user has spy access, while author scenario loading must remain unchanged.

### Description
- Added `autoRefreshTicker` and `lastAutoRefreshMark` to `GamePlayComponent` and wired start/cleanup in `ngOnInit`/`ngOnDestroy` so polling runs only while the component is active.
- Implemented `tryAutoRefreshCurrentGame` which computes `elapsedSeconds = Math.floor((Date.now() - Date.parse(hints.started_at)) / 1000)`, ignores elapsed < 61s, computes `refreshMark = Math.floor((elapsedSeconds - 1) / 60)` and triggers a refresh only when the mark advances.
- On a refresh mark change the component calls `gameService.loadHints()` to repaint the current hints and, if `canOpenSpyTab()` is true, force-refreshes spy data with `gameService.loadSpyData(..., true)`.
- Changed file: `src/app/game_play/game_play.component.ts` (added ticker, refresh logic and lifecycle handling) and left author scenario loading behavior intact.

### Testing
- Ran `npm run build`, which completed successfully (Angular emitted existing bundle/style budget warnings but exited with code 0).
- No unit tests were added or modified in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69edcc96cf8c832a947d1298ad7bfc6c)