### PR TITLE
Gate current hints by waiver vote and split spy permissions

### DIFF
--- a/src/app/game_log.part/game_log.part.component.html
+++ b/src/app/game_log.part/game_log.part.component.html
@@ -1,5 +1,5 @@
 @if (keys) {
-  <details>
+  <details [attr.open]="openKeys ? '' : null">
     <summary class="game-keys-spoiler">Ключи</summary>
     <div class="keys-log">
       @for (teamKeys of Object.entries(keys); track teamKeys[0]) {
@@ -57,7 +57,7 @@
 }
 
 @if (stat) {
-  <details>
+  <details [attr.open]="openStat ? '' : null">
     <summary class="game-stat-spoiler">Результаты игры</summary>
     <div class="game-stat">
       @if (Object.keys(stat).length > 0) {

--- a/src/app/game_log.part/game_log.part.component.html
+++ b/src/app/game_log.part/game_log.part.component.html
@@ -66,15 +66,8 @@
             <thead>
             <tr>
               <th>Команда</th>
-              @for (header of getLevelHeaders(); track header.number) {
-                <th>
-                  Уровень {{ header.number }}
-                  @if (header.name) {
-                    <br>
-                    {{ header.name }}
-                  }
-                </th>
-              }
+              <th>Текущий уровень</th>
+              <th>Время на уровне</th>
             </tr>
             </thead>
             <tbody>
@@ -82,11 +75,8 @@
                 @if (results[1].length > 0) {
                   <tr>
                     <td>{{ results[1][0].team.name }}</td>
-                    @for (lt of results[1]; track lt.id) {
-                      @if (!$first) {
-                        <td>{{ toLocal(lt.start_at) }}</td>
-                      }
-                    }
+                    <td>{{ getCurrentLevelNumber(results[1]) }}</td>
+                    <td [title]="getLevelStartedAtTitle(results[1])">{{ getCurrentLevelDuration(results[1]) }}</td>
                   </tr>
                 }
               }

--- a/src/app/game_log.part/game_log.part.component.ts
+++ b/src/app/game_log.part/game_log.part.component.ts
@@ -16,6 +16,8 @@ export class GameLogPartComponent {
   @Input() keys: Keys | undefined;
   @Input() stat: GameStat | undefined;
   @Input() levels: Level[] = [];
+  @Input() openKeys = false;
+  @Input() openStat = false;
 
   toLocal(dt: string): string {
     return new Date(Date.parse(dt)).toLocaleTimeString();

--- a/src/app/game_log.part/game_log.part.component.ts
+++ b/src/app/game_log.part/game_log.part.component.ts
@@ -1,11 +1,6 @@
 import {Component, Input} from '@angular/core';
 import {GameStat, Keys, KeyType, Level, LevelTime} from "../domain/game.models";
 
-interface LevelHeader {
-  number: number;
-  name: string | undefined;
-}
-
 @Component({
   selector: 'app-game-log-part',
   standalone: true,
@@ -23,27 +18,47 @@ export class GameLogPartComponent {
     return new Date(Date.parse(dt)).toLocaleTimeString();
   }
 
-  getLevelHeaders(): LevelHeader[] {
-    if (this.levels.length > 0) {
-      return this.levels.map(level => ({
-        number: (level.number_in_game ?? 0) + 1,
-        name: level.name_id,
-      }));
+  getCurrentLevelNumber(teamLevelTimes: LevelTime[]): number {
+    const currentLevel = teamLevelTimes[teamLevelTimes.length - 1];
+    return (currentLevel?.level_number ?? 0) + 1;
+  }
+
+  getCurrentLevelDuration(teamLevelTimes: LevelTime[]): string {
+    const currentLevel = teamLevelTimes[teamLevelTimes.length - 1];
+    const startedAtMs = this.parseDate(currentLevel?.start_at);
+    if (startedAtMs === undefined) {
+      return "—";
     }
 
-    const firstTeamWithResults = Object.values(this.stat?.level_times ?? {})
-      .find(teamLevelTimes => teamLevelTimes.length > 1);
+    const totalSeconds = Math.max(Math.floor((Date.now() - startedAtMs) / 1000), 0);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
 
-    if (!firstTeamWithResults) {
-      return [];
+    if (hours > 0) {
+      return `${hours}ч ${minutes}м ${seconds}с`;
     }
 
-    return firstTeamWithResults
-      .slice(1)
-      .map((lt: LevelTime) => ({
-        number: lt.level_number + 1,
-        name: undefined,
-      }));
+    return `${minutes}м ${seconds}с`;
+  }
+
+  getLevelStartedAtTitle(teamLevelTimes: LevelTime[]): string {
+    const currentLevel = teamLevelTimes[teamLevelTimes.length - 1];
+    const startedAtMs = this.parseDate(currentLevel?.start_at);
+    if (startedAtMs === undefined) {
+      return "";
+    }
+
+    return `Уровень начался: ${new Date(startedAtMs).toLocaleTimeString()}`;
+  }
+
+  private parseDate(value: string | Date | undefined): number | undefined {
+    if (!value) {
+      return undefined;
+    }
+
+    const parsed = Date.parse(String(value));
+    return Number.isNaN(parsed) ? undefined : parsed;
   }
 
   protected readonly KeyType = KeyType;

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -159,7 +159,20 @@
   <div class="spy-panel">
     <div class="spy-panel-header">
       <h3>Лог текущей игры (организатор)</h3>
-      <button type="button" (click)="loadSpyData(true)">Обновить</button>
+      <button
+        type="button"
+        [disabled]="isSpyDataLoading()"
+        (click)="loadSpyData(true)"
+        style="background:none;border:none;color:#2563eb;padding:0;border-radius:0;text-decoration:underline;"
+        [style.cursor]="isSpyDataLoading() ? 'not-allowed' : 'pointer'"
+        [style.opacity]="isSpyDataLoading() ? '0.7' : '1'"
+      >
+        @if (isSpyDataLoading()) {
+          Обновление...
+        } @else {
+          Обновить
+        }
+      </button>
     </div>
 
     @if (isSpyDataLoading() && !isSpyKeysDataLoading() && !isSpyStatDataLoading()) {
@@ -170,7 +183,7 @@
       @if (isSpyKeysDataLoading()) {
         <p class="status-message">Загрузка ключей...</p>
       } @else if (getSpyKeys()) {
-        <app-game-log-part [keys]="getSpyKeys()" [openKeys]="true"></app-game-log-part>
+        <app-game-log-part [keys]="getSpyKeys()"></app-game-log-part>
       } @else {
         <p class="status-message">Ключи пока недоступны.</p>
       }
@@ -180,7 +193,7 @@
       @if (isSpyStatDataLoading()) {
         <p class="status-message">Загрузка статистики...</p>
       } @else if (getSpyStat()) {
-        <app-game-log-part [stat]="getSpyStat()" [openStat]="true"></app-game-log-part>
+        <app-game-log-part [stat]="getSpyStat()"></app-game-log-part>
       } @else {
         <p class="status-message">Статистика пока недоступна.</p>
       }

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -158,7 +158,7 @@
 @if (canOpenSpyTab()) {
   <div class="spy-panel">
     <div class="spy-panel-header">
-      <h3>Spy</h3>
+      <h3>Лог текущей игры (организатор)</h3>
       <button type="button" (click)="loadSpyData(true)">Обновить</button>
     </div>
 
@@ -170,7 +170,7 @@
       @if (isSpyKeysDataLoading()) {
         <p class="status-message">Загрузка ключей...</p>
       } @else if (getSpyKeys()) {
-        <app-game-log-part [keys]="getSpyKeys()"></app-game-log-part>
+        <app-game-log-part [keys]="getSpyKeys()" [openKeys]="true"></app-game-log-part>
       } @else {
         <p class="status-message">Ключи пока недоступны.</p>
       }
@@ -180,7 +180,7 @@
       @if (isSpyStatDataLoading()) {
         <p class="status-message">Загрузка статистики...</p>
       } @else if (getSpyStat()) {
-        <app-game-log-part [stat]="getSpyStat()"></app-game-log-part>
+        <app-game-log-part [stat]="getSpyStat()" [openStat]="true"></app-game-log-part>
       } @else {
         <p class="status-message">Статистика пока недоступна.</p>
       }

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -158,12 +158,11 @@
 @if (canOpenSpyTab()) {
   <div class="spy-panel">
     <div class="spy-panel-header">
-      <h3>Лог текущей игры (организатор)</h3>
+      <h3>Шпион (организатор)</h3>
       <button
         type="button"
         [disabled]="isSpyDataLoading()"
         (click)="loadSpyData(true)"
-        style="background:none;border:none;color:#2563eb;padding:0;border-radius:0;text-decoration:underline;"
         [style.cursor]="isSpyDataLoading() ? 'not-allowed' : 'pointer'"
         [style.opacity]="isSpyDataLoading() ? '0.7' : '1'"
       >
@@ -176,7 +175,7 @@
     </div>
 
     @if (isSpyDataLoading() && !isSpyKeysDataLoading() && !isSpyStatDataLoading()) {
-      <p class="status-message">Загрузка spy-данных...</p>
+      <p class="status-message">Загрузка данных шпиона...</p>
     }
 
     @if (canSeeSpyKeys()) {

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -162,12 +162,28 @@
       <button type="button" (click)="loadSpyData(true)">Обновить</button>
     </div>
 
-    @if (isSpyDataLoading()) {
+    @if (isSpyDataLoading() && !isSpyKeysDataLoading() && !isSpyStatDataLoading()) {
       <p class="status-message">Загрузка spy-данных...</p>
     }
 
-    @if (getSpyKeys() || getSpyStat()) {
-      <app-game-log-part [keys]="getSpyKeys()" [stat]="getSpyStat()"></app-game-log-part>
+    @if (canSeeSpyKeys()) {
+      @if (isSpyKeysDataLoading()) {
+        <p class="status-message">Загрузка ключей...</p>
+      } @else if (getSpyKeys()) {
+        <app-game-log-part [keys]="getSpyKeys()"></app-game-log-part>
+      } @else {
+        <p class="status-message">Ключи пока недоступны.</p>
+      }
+    }
+
+    @if (canSeeSpyStat()) {
+      @if (isSpyStatDataLoading()) {
+        <p class="status-message">Загрузка статистики...</p>
+      } @else if (getSpyStat()) {
+        <app-game-log-part [stat]="getSpyStat()"></app-game-log-part>
+      } @else {
+        <p class="status-message">Статистика пока недоступна.</p>
+      }
     }
   </div>
 }

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -201,6 +201,24 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     return this.gameService.isSpyDataLoading();
   }
 
+  isSpyKeysDataLoading(): boolean {
+    return this.gameService.isSpyKeysDataLoading();
+  }
+
+  isSpyStatDataLoading(): boolean {
+    return this.gameService.isSpyStatDataLoading();
+  }
+
+  canSeeSpyKeys(): boolean {
+    const org = this.gameService.getMyRole()?.org;
+    return !!org && !org.deleted && org.can_see_log_keys;
+  }
+
+  canSeeSpyStat(): boolean {
+    const org = this.gameService.getMyRole()?.org;
+    return !!org && !org.deleted && org.can_spy;
+  }
+
   getSpyKeys(): Keys | undefined {
     return this.gameService.getSpyKeys();
   }

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -186,7 +186,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
 
   canOpenSpyTab(): boolean {
     const org = this.gameService.getMyRole()?.org;
-    return this.activeGame?.status === "running" && !!org && !org.deleted && (org.can_spy || org.can_see_log_keys);
+    return !!org && !org.deleted && (org.can_spy || org.can_see_log_keys);
   }
 
   loadSpyData(forceRefresh: boolean = false) {

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -408,7 +408,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   }
 
   private tryAutoRefreshCurrentGame() {
-    if (this.activeGame?.status !== "running") {
+    if (this.activeGame?.status !== "started") {
       this.lastAutoRefreshMark = undefined;
       return;
     }

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -185,7 +185,8 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   }
 
   canOpenSpyTab(): boolean {
-    return this.activeGame?.status === "running" && !!this.gameService.getMyRole()?.org?.can_spy;
+    const org = this.gameService.getMyRole()?.org;
+    return this.activeGame?.status === "running" && !!org && !org.deleted && (org.can_spy || org.can_see_log_keys);
   }
 
   loadSpyData(forceRefresh: boolean = false) {

--- a/src/app/game_play/game_play.service.ts
+++ b/src/app/game_play/game_play.service.ts
@@ -162,14 +162,21 @@ export class GamePlayService {
         return;
       }
 
-      this.loadMyRole(game);
-
       if (game.status === "getting_waivers") {
+        this.loadMyRole(game);
         this.loadWaivers();
         return;
       }
 
-      this.loadRunningHints();
+      this.loadMyRole(game, false, role => {
+        if (role?.waiver_vote === Played.yes) {
+          this.loadRunningHints();
+          return;
+        }
+
+        this.currentHints = undefined;
+        this.isHintsLoading = false;
+      });
     });
   }
 
@@ -218,13 +225,15 @@ export class GamePlayService {
       });
   }
 
-  private loadMyRole(game: ActiveGame, forceRefresh = false) {
+  private loadMyRole(game: ActiveGame, forceRefresh = false, onLoaded?: (role: MyRoleDto | undefined) => void) {
     const cacheValid = !forceRefresh
       && this.myRole !== undefined
       && this.myRoleGameId === game.id
       && (this.myRoleCacheUntil === undefined || this.myRoleCacheUntil > Date.now());
 
     if (cacheValid) {
+      this.maybeLoadSpyData(game.id, this.myRole);
+      onLoaded?.(this.myRole);
       return;
     }
 
@@ -234,21 +243,31 @@ export class GamePlayService {
           this.myRole = role;
           this.myRoleGameId = game.id;
           this.myRoleCacheUntil = this.resolveRoleCacheUntil(game);
-          if (game.status === "running" && role.org?.can_spy) {
-            this.loadSpyData(game.id);
-          }
+          this.maybeLoadSpyData(game.id, role);
+          onLoaded?.(role);
         },
         error: error => {
           if (error instanceof HttpErrorResponse && error.status === 401) {
             this.myRole = undefined;
             this.myRoleGameId = undefined;
             this.myRoleCacheUntil = undefined;
+            onLoaded?.(undefined);
             return;
           }
 
           throw error;
         }
       });
+  }
+
+  private maybeLoadSpyData(gameId: number, role: MyRoleDto | undefined) {
+    if (!role?.org || role.org.deleted) {
+      return;
+    }
+
+    if (role.org.can_spy || role.org.can_see_log_keys) {
+      this.loadSpyData(gameId);
+    }
   }
 
   private resolveRoleCacheUntil(game: ActiveGame): number | undefined {
@@ -266,45 +285,66 @@ export class GamePlayService {
   }
 
   loadSpyData(gameId: number, forceRefresh: boolean = false) {
+    const org = this.myRole?.org;
+    const canLoadStat = !!org && !org.deleted && org.can_spy;
+    const canLoadKeys = !!org && !org.deleted && org.can_see_log_keys;
+
+    if (!canLoadStat && !canLoadKeys) {
+      this.spyGameId = gameId;
+      this.spyKeys = undefined;
+      this.spyStat = undefined;
+      this.isSpyLoading = false;
+      this.spyLoadingRequests = 0;
+      return;
+    }
+
     if (this.spyGameId !== gameId) {
       this.spyGameId = gameId;
       this.spyKeys = undefined;
       this.spyStat = undefined;
     }
 
-    if (!forceRefresh && this.spyKeys && this.spyStat) {
+    if (!forceRefresh && (!canLoadKeys || this.spyKeys) && (!canLoadStat || this.spyStat)) {
       return;
     }
 
-    this.spyLoadingRequests = 2;
+    this.spyLoadingRequests = Number(canLoadKeys) + Number(canLoadStat);
     this.isSpyLoading = true;
-    this.http.get<Keys>(`/games/${gameId}/keys`)
-      .subscribe({
-        next: k => {
-          this.spyKeys = k;
-          this.completeSpyLoadRequest();
-        },
-        error: error => {
-          this.completeSpyLoadRequest();
-          if (!(error instanceof HttpErrorResponse && error.status === 401)) {
-            throw error;
+    if (canLoadKeys) {
+      this.http.get<Keys>(`/games/${gameId}/keys`)
+        .subscribe({
+          next: k => {
+            this.spyKeys = k;
+            this.completeSpyLoadRequest();
+          },
+          error: error => {
+            this.completeSpyLoadRequest();
+            if (!(error instanceof HttpErrorResponse && error.status === 401)) {
+              throw error;
+            }
           }
-        }
-      });
+        });
+    } else {
+      this.spyKeys = undefined;
+    }
 
-    this.http.get<GameStat>(`/games/${gameId}/stat`)
-      .subscribe({
-        next: s => {
-          this.spyStat = s;
-          this.completeSpyLoadRequest();
-        },
-        error: error => {
-          this.completeSpyLoadRequest();
-          if (!(error instanceof HttpErrorResponse && error.status === 401)) {
-            throw error;
+    if (canLoadStat) {
+      this.http.get<GameStat>(`/games/${gameId}/stat`)
+        .subscribe({
+          next: s => {
+            this.spyStat = s;
+            this.completeSpyLoadRequest();
+          },
+          error: error => {
+            this.completeSpyLoadRequest();
+            if (!(error instanceof HttpErrorResponse && error.status === 401)) {
+              throw error;
+            }
           }
-        }
-      });
+        });
+    } else {
+      this.spyStat = undefined;
+    }
   }
 
   private completeSpyLoadRequest() {

--- a/src/app/game_play/game_play.service.ts
+++ b/src/app/game_play/game_play.service.ts
@@ -137,6 +137,8 @@ export class GamePlayService {
   private spyStat: GameStat | undefined;
   private spyLoadingRequests = 0;
   private isSpyLoading = false;
+  private isSpyKeysLoading = false;
+  private isSpyStatLoading = false;
   private isHintsLoading = false;
   private authRequired = false;
 
@@ -294,6 +296,8 @@ export class GamePlayService {
       this.spyKeys = undefined;
       this.spyStat = undefined;
       this.isSpyLoading = false;
+      this.isSpyKeysLoading = false;
+      this.isSpyStatLoading = false;
       this.spyLoadingRequests = 0;
       return;
     }
@@ -310,14 +314,18 @@ export class GamePlayService {
 
     this.spyLoadingRequests = Number(canLoadKeys) + Number(canLoadStat);
     this.isSpyLoading = true;
+    this.isSpyKeysLoading = canLoadKeys;
+    this.isSpyStatLoading = canLoadStat;
     if (canLoadKeys) {
       this.http.get<Keys>(`/games/${gameId}/keys`)
         .subscribe({
           next: k => {
             this.spyKeys = k;
+            this.isSpyKeysLoading = false;
             this.completeSpyLoadRequest();
           },
           error: error => {
+            this.isSpyKeysLoading = false;
             this.completeSpyLoadRequest();
             if (!(error instanceof HttpErrorResponse && error.status === 401)) {
               throw error;
@@ -325,6 +333,7 @@ export class GamePlayService {
           }
         });
     } else {
+      this.isSpyKeysLoading = false;
       this.spyKeys = undefined;
     }
 
@@ -333,9 +342,11 @@ export class GamePlayService {
         .subscribe({
           next: s => {
             this.spyStat = s;
+            this.isSpyStatLoading = false;
             this.completeSpyLoadRequest();
           },
           error: error => {
+            this.isSpyStatLoading = false;
             this.completeSpyLoadRequest();
             if (!(error instanceof HttpErrorResponse && error.status === 401)) {
               throw error;
@@ -343,6 +354,7 @@ export class GamePlayService {
           }
         });
     } else {
+      this.isSpyStatLoading = false;
       this.spyStat = undefined;
     }
   }
@@ -374,6 +386,14 @@ export class GamePlayService {
 
   isSpyDataLoading(): boolean {
     return this.isSpyLoading;
+  }
+
+  isSpyKeysDataLoading(): boolean {
+    return this.isSpyKeysLoading;
+  }
+
+  isSpyStatDataLoading(): boolean {
+    return this.isSpyStatLoading;
   }
 
   hintsLoading(): boolean {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -160,7 +160,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
       return false;
     }
 
-    if (this.activeGame.status === "running") {
+    if (this.activeGame.status === "started") {
       return true;
     }
 
@@ -176,7 +176,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   isFinishedStatus() {
-    return this.activeGame?.status === "finished";
+    return this.activeGame?.status === "finished" || this.activeGame?.status === "complete";
   }
 
   isOtherPreStartStatus() {
@@ -195,7 +195,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
       this.countdownInterval = undefined;
     }
 
-    if (!this.activeGame?.start_at || this.activeGame.status === "running" || this.activeGame.status === "finished") {
+    if (!this.activeGame?.start_at || this.activeGame.status === "started" || this.isFinishedStatus()) {
       return;
     }
 
@@ -236,7 +236,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   private getCountdown(): Countdown | undefined {
-    if (!this.activeGame?.start_at || this.activeGame.status === "running" || this.activeGame.status === "finished") {
+    if (!this.activeGame?.start_at || this.activeGame.status === "started" || this.isFinishedStatus()) {
       return undefined;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent loading current running hints for players who didn't vote to play by gating requests on `waiver_vote === Played.yes` from `/games/active/me`.
- Respect organizer granular permissions and deleted state when loading spy data so organizers only receive what they are allowed to see.

### Description
- Changed `loadHints()` to fetch the current role first and only call `loadRunningHints()` when `role.waiver_vote === Played.yes`, otherwise clear `currentHints` and stop loading them (`src/app/game_play/game_play.service.ts`).
- Extended `loadMyRole()` to accept an optional callback and introduced `maybeLoadSpyData()` to decide spy preloading based on organizer permissions and `deleted` flag (`src/app/game_play/game_play.service.ts`).
- Split `loadSpyData()` into permission-aware branches so `/games/{id}/stat` is requested only when `org.can_spy` and `/games/{id}/keys` only when `org.can_see_log_keys`, and avoid loading either when organizer is deleted (`src/app/game_play/game_play.service.ts`).
- Updated spy panel visibility to allow opening when the organizer has either `can_spy` or `can_see_log_keys` and is not deleted (`src/app/game_play/game_play.component.ts`).

### Testing
- Ran `npm run build` which completed successfully (Angular emitted existing bundle/style budget warnings but no build errors).
- Verified there are no new TypeScript or Angular build errors introduced by the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ede96adb7c832abb394983dbcaeba0)