### PR TITLE
Fix Telegram mini-app instant auth ordering and add in-app debug logs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,11 +11,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - name: Get current date
-        id: date
+      - name: Prepare build metadata
+        id: meta
         run: |
-          echo "BUILD_AT=$(date +'%Y-%m-%dT%H:%M:%S%z')" >> "$GITHUB_OUTPUT"
-          echo "VCS_SHA=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "BUILD_AT=$(date -u +'%Y-%m-%dT%H:%M:%S%z')" >> "$GITHUB_OUTPUT"
+          echo "VCS_HASH=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "COMMIT_AT=$(git show -s --format=%cI ${GITHUB_SHA})" >> "$GITHUB_OUTPUT"
+
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            echo "VCS_TAG=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+            echo "VCS_BRANCH=" >> "$GITHUB_OUTPUT"
+          else
+            echo "VCS_TAG=" >> "$GITHUB_OUTPUT"
+            echo "VCS_BRANCH=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+          fi
       - uses: mr-smithers-excellent/docker-build-push@v6.2
         with:
           image: bomzheg/shvatka-ui
@@ -23,4 +32,4 @@ jobs:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          buildArgs: "BUILD_AT=${{steps.date.outputs.BUILD_AT}},VCS_SHA=${{steps.date.outputs.VCS_SHA}}"
+          buildArgs: "BUILD_AT=${{ steps.meta.outputs.BUILD_AT }},VCS_HASH=${{ steps.meta.outputs.VCS_HASH }},VCS_BRANCH=${{ steps.meta.outputs.VCS_BRANCH }},VCS_TAG=${{ steps.meta.outputs.VCS_TAG }},COMMIT_AT=${{ steps.meta.outputs.COMMIT_AT }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,14 +17,7 @@ jobs:
           echo "BUILD_AT=$(date -u +'%Y-%m-%dT%H:%M:%S%z')" >> "$GITHUB_OUTPUT"
           echo "VCS_HASH=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           echo "COMMIT_AT=$(git show -s --format=%cI ${GITHUB_SHA})" >> "$GITHUB_OUTPUT"
-
-          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
-            echo "VCS_TAG=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-            echo "VCS_BRANCH=" >> "$GITHUB_OUTPUT"
-          else
-            echo "VCS_TAG=" >> "$GITHUB_OUTPUT"
-            echo "VCS_BRANCH=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          fi
+          echo "VCS_NAME=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
       - uses: mr-smithers-excellent/docker-build-push@v6.2
         with:
           image: bomzheg/shvatka-ui
@@ -32,4 +25,4 @@ jobs:
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          buildArgs: "BUILD_AT=${{ steps.meta.outputs.BUILD_AT }},VCS_HASH=${{ steps.meta.outputs.VCS_HASH }},VCS_BRANCH=${{ steps.meta.outputs.VCS_BRANCH }},VCS_TAG=${{ steps.meta.outputs.VCS_TAG }},COMMIT_AT=${{ steps.meta.outputs.COMMIT_AT }}"
+          buildArgs: "BUILD_AT=${{ steps.meta.outputs.BUILD_AT }},VCS_HASH=${{ steps.meta.outputs.VCS_HASH }},VCS_NAME=${{ steps.meta.outputs.VCS_NAME }},COMMIT_AT=${{ steps.meta.outputs.COMMIT_AT }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:20.11.0 as build
 WORKDIR /usr/local/app
+ARG VCS_HASH
+ARG VCS_BRANCH
+ARG VCS_TAG
+ARG COMMIT_AT
+ARG BUILD_AT
 
 # Install dependencies in a separate layer to maximize Docker build cache reuse.
 COPY package.json package-lock.json ./
@@ -7,6 +12,15 @@ RUN npm ci
 
 # Copy application source and build.
 COPY . .
+RUN set -eux; \
+    vcs_hash="${VCS_HASH:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"; \
+    vcs_branch="${VCS_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')}"; \
+    vcs_tag="${VCS_TAG:-$(git describe --tags --exact-match 2>/dev/null || echo '')}"; \
+    commit_at="${COMMIT_AT:-$(git show -s --format=%cI HEAD 2>/dev/null || echo '')}"; \
+    build_at="${BUILD_AT:-$(date -u +"%Y-%m-%dT%H:%M:%S%z")}"; \
+    vcs_ref="${vcs_tag:-$vcs_branch}"; \
+    printf '{\n  "vcs_hash": "%s",\n  "vcs_ref": "%s",\n  "vcs_branch": "%s",\n  "vcs_tag": "%s",\n  "commit_at": "%s",\n  "build_at": "%s"\n}\n' \
+      "$vcs_hash" "$vcs_ref" "$vcs_branch" "$vcs_tag" "$commit_at" "$build_at" > src/assets/frontend-version.json
 RUN npm run build
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,11 @@ RUN npm ci
 COPY . .
 RUN set -eux; \
     vcs_hash="${VCS_HASH:-$(git rev-parse HEAD 2>/dev/null || echo unknown)}"; \
-    vcs_branch="${VCS_BRANCH:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')}"; \
-    vcs_tag="${VCS_TAG:-$(git describe --tags --exact-match 2>/dev/null || echo '')}"; \
+    vcs_name="${VCS_NAME:-$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')}"; \
     commit_at="${COMMIT_AT:-$(git show -s --format=%cI HEAD 2>/dev/null || echo '')}"; \
     build_at="${BUILD_AT:-$(date -u +"%Y-%m-%dT%H:%M:%S%z")}"; \
-    vcs_ref="${vcs_tag:-$vcs_branch}"; \
-    printf '{\n  "vcs_hash": "%s",\n  "vcs_ref": "%s",\n  "vcs_branch": "%s",\n  "vcs_tag": "%s",\n  "commit_at": "%s",\n  "build_at": "%s"\n}\n' \
-      "$vcs_hash" "$vcs_ref" "$vcs_branch" "$vcs_tag" "$commit_at" "$build_at" > src/assets/frontend-version.json
+    printf '{\n  "vcs_hash": "%s",\n  "vcs_ref": "%s",\n  "vcs_name": "%s",\n  "commit_at": "%s",\n  "build_at": "%s"\n}\n' \
+      "$vcs_hash" "$vcs_name" "$commit_at" "$build_at" > src/assets/frontend-version.json
 RUN npm run build
 
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,28 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
 
+### Docker/CI build metadata
+
+Docker image build writes frontend metadata into `src/assets/frontend-version.json` (shown in UI footer):
+- `vcs_hash`
+- `vcs_ref` (`tag` if present, otherwise `branch`)
+- `vcs_branch`
+- `vcs_tag`
+- `commit_at`
+- `build_at`
+
+You can pass explicit values from pipeline:
+
+```bash
+docker build \
+  --build-arg VCS_HASH="$CI_COMMIT_SHA" \
+  --build-arg VCS_BRANCH="$CI_COMMIT_BRANCH" \
+  --build-arg VCS_TAG="$CI_COMMIT_TAG" \
+  --build-arg COMMIT_AT="$CI_COMMIT_TIMESTAMP" \
+  --build-arg BUILD_AT="$(date -u +"%Y-%m-%dT%H:%M:%S%z")" \
+  -t shvatka-ui:latest .
+```
+
 ## Running unit tests
 
 Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -4,3 +4,11 @@
     <router-outlet/>
   </div>
 </main>
+<footer class="version-footer">
+  <button class="version-button" type="button" (click)="toggleDebugInfo()">
+    FE {{ formatVersionShort(frontendVersion) }} {{ formatVersionTime(frontendVersion) }}
+    ·
+    BE {{ formatVersionShort(backendVersion) }} {{ formatVersionTime(backendVersion) }}
+  </button>
+  <pre *ngIf="showDebugInfo" class="debug-panel">{{ telegramAuthDebugInfo || "No tg auth debug logs yet." }}</pre>
+</footer>

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,6 +1,7 @@
 :host {
   display: block;
   min-height: 100dvh;
+  padding-bottom: 1rem;
 }
 
 .app-shell {
@@ -14,6 +15,34 @@
   border-radius: 16px;
   padding: clamp(1rem, 2vw, 1.5rem);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+.version-footer {
+  width: min(1100px, calc(100% - 2rem));
+  margin: 0 auto 1rem;
+  color: color-mix(in srgb, var(--app-text) 75%, transparent);
+}
+
+.version-button {
+  width: 100%;
+  background: transparent;
+  border: 0;
+  color: inherit;
+  text-align: center;
+  cursor: pointer;
+  font-size: 0.78rem;
+  opacity: 0.85;
+}
+
+.debug-panel {
+  margin-top: 0.5rem;
+  padding: 0.75rem;
+  border-radius: 8px;
+  font-size: 0.72rem;
+  max-height: 180px;
+  overflow: auto;
+  background: color-mix(in srgb, var(--app-surface) 90%, black 10%);
+  color: var(--app-text);
 }
 
 @media (max-width: 768px) {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,11 +1,12 @@
-import {Component} from '@angular/core';
+import {Component, Inject, OnInit} from '@angular/core';
 import {MatIconRegistry} from '@angular/material/icon';
-import {APP_BASE_HREF, CommonModule} from '@angular/common';
+import {APP_BASE_HREF, CommonModule, DOCUMENT} from '@angular/common';
 import {RouterOutlet} from '@angular/router';
 import {HeaderComponent} from "./header/header.component";
 import {environment} from "../environments/environment";
 import {DomSanitizer} from "@angular/platform-browser";
 import {ThemeService} from "./theme/theme.service";
+import {VersionInfo, VersionService} from "./version/version.service";
 
 @Component({
   selector: 'app-root',
@@ -17,18 +18,55 @@ import {ThemeService} from "./theme/theme.service";
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss',
 })
-export class AppComponent {
+export class AppComponent implements OnInit {
   title = 'shvatka';
+  frontendVersion: VersionInfo | undefined;
+  backendVersion: VersionInfo | undefined;
+  showDebugInfo = false;
+  telegramAuthDebugInfo = "";
+  private readonly window: (Window & typeof globalThis) | undefined;
+
   constructor(
     private matIconRegistry: MatIconRegistry,
     domSanitizer:DomSanitizer,
     private themeService: ThemeService,
+    private versionService: VersionService,
+    @Inject(DOCUMENT) private document: Document,
   ) {
     this.matIconRegistry.addSvgIcon(
       "account-circle",
       domSanitizer.bypassSecurityTrustResourceUrl('/assets/account_circle.svg')
     );
     this.themeService.getMode();
+    this.window = this.document.defaultView ?? undefined;
   }
 
+  ngOnInit() {
+    this.versionService.getFrontendVersion().subscribe(version => this.frontendVersion = version);
+    this.versionService.getBackendVersion().subscribe(version => this.backendVersion = version);
+    this.telegramAuthDebugInfo = this.window?.sessionStorage.getItem("tg-auth-debug-log") ?? "";
+  }
+
+  toggleDebugInfo() {
+    this.showDebugInfo = !this.showDebugInfo;
+    this.telegramAuthDebugInfo = this.window?.sessionStorage.getItem("tg-auth-debug-log") ?? "";
+  }
+
+  formatVersionShort(version: VersionInfo | undefined): string {
+    if (!version) {
+      return "n/a";
+    }
+
+    const ref = version.vcs_tag || version.vcs_branch || version.vcs_ref;
+    const hash = version.vcs_hash ? version.vcs_hash.slice(0, 8) : "unknown";
+    return ref ? `${ref}@${hash}` : hash;
+  }
+
+  formatVersionTime(version: VersionInfo | undefined): string {
+    if (!version) {
+      return "";
+    }
+
+    return version.build_at || version.commit_at || "";
+  }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -57,7 +57,7 @@ export class AppComponent implements OnInit {
       return "n/a";
     }
 
-    const ref = version.vcs_tag || version.vcs_branch || version.vcs_ref;
+    const ref = version.vcs_name;
     const hash = version.vcs_hash ? version.vcs_hash.slice(0, 8) : "unknown";
     return ref ? `${ref}@${hash}` : hash;
   }

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -202,7 +202,7 @@
 
 @if (isCurrentUserGameAuthor()) {
   <details class="author-scenario-spoiler">
-    <summary>Сценарий текущей игры</summary>
+    <summary class="game-scn-spoiler">Сценарий текущей игры</summary>
     @if (isAuthorScenarioLoading) {
       <p class="status-message">Загрузка сценария...</p>
     } @else if (shouldShowAuthorScenario()) {

--- a/src/app/game_play/game_play.component.scss
+++ b/src/app/game_play/game_play.component.scss
@@ -6,6 +6,7 @@
   color: var(--tg-theme-hint-color, #6b7280);
 }
 
+.game-scn-spoiler,
 .level-header {
   text-align: center;
 }

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -121,34 +121,14 @@ export class HeaderComponent implements OnInit, OnDestroy {
       return;
     }
 
-    let authResolved = false;
-
-    const normalAuthPromise = this.userService.loadMe();
-    const telegramAuthPromise = this.tryTelegramAuthWithTimeout();
-
-    const winner = await Promise.race([
-      normalAuthPromise.then(() => "normal" as const),
-      telegramAuthPromise.then((telegramAuthenticated) => telegramAuthenticated ? "telegram" as const : "telegram-failed" as const),
-    ]);
-
-    if (winner === "normal") {
-      authResolved = true;
-      return;
-    }
-
-    if (winner === "telegram") {
-      if (authResolved) {
-        return;
-      }
-
-      authResolved = true;
+    const telegramAuthResult = await this.tryTelegramAuthWithTimeout();
+    if (telegramAuthResult) {
       await this.userService.loadMe();
       this.getTelegramWebApp()?.ready?.();
       return;
     }
 
-    await normalAuthPromise;
-    authResolved = true;
+    await this.userService.loadMe();
   }
 
   hasActiveGame() {
@@ -356,6 +336,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   private async tryTelegramAuthWithTimeout(): Promise<boolean> {
     if (!this.shouldTryTelegramSdkLoad()) {
+      this.logTelegramAuthDebug("skip: no telegram markers in url/userAgent");
       return false;
     }
 
@@ -363,19 +344,47 @@ export class HeaderComponent implements OnInit, OnDestroy {
       await this.loadTelegramSDK();
       const tgWa = this.getTelegramWebApp();
       if (!tgWa?.initData) {
+        this.logTelegramAuthDebug("skip: telegram sdk loaded but initData is empty");
         return false;
       }
 
+      this.logTelegramAuthDebug(`attempt: authenticate webapp (initDataLength=${tgWa.initData.length})`);
       return await new Promise<boolean>((resolve) => {
         this.authService.authenticateWebApp(tgWa)
           .subscribe({
-            next: () => resolve(true),
-            error: () => resolve(false),
+            next: () => {
+              this.logTelegramAuthDebug("success: authenticateWebApp");
+              resolve(true);
+            },
+            error: (error) => {
+              const status = typeof error?.status === "number" ? error.status : "unknown";
+              this.logTelegramAuthDebug(`failed: authenticateWebApp status=${status}`);
+              resolve(false);
+            },
           });
       });
-    } catch {
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown error";
+      this.logTelegramAuthDebug(`failed: telegram sdk load error (${message})`);
       return false;
     }
+  }
+
+  private logTelegramAuthDebug(message: string) {
+    const timestamp = new Date().toISOString();
+    const line = `[tg-auth][${timestamp}] ${message}`;
+    console.info(line);
+
+    if (!this.window) {
+      return;
+    }
+
+    const key = "tg-auth-debug-log";
+    const existing = this.window.sessionStorage.getItem(key);
+    const currentLines = existing ? existing.split("\n").filter(Boolean) : [];
+    currentLines.push(line);
+    const tail = currentLines.slice(-40);
+    this.window.sessionStorage.setItem(key, tail.join("\n"));
   }
 
   countdownUnitLabel(unit: CountdownUnit): string {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -364,82 +364,66 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   private authenticateTelegramWebApp(tgWa: any): Promise<boolean> {
-    const payloads = this.buildTelegramWebAppPayloads(tgWa);
-    return this.authenticateTelegramWebAppRecursive(payloads, 0);
-  }
-
-  private authenticateTelegramWebAppRecursive(payloads: any[], index: number): Promise<boolean> {
-    if (index >= payloads.length) {
-      return Promise.resolve(false);
-    }
-
-    const currentPayload = payloads[index];
-    const payloadKeys = Object.keys(currentPayload).join(",");
-    this.logTelegramAuthDebug(`attempt: authenticateWebApp payload#${index + 1} keys=[${payloadKeys}]`);
+    const payload = this.buildTelegramWebAppPayload(tgWa);
+    const payloadKeys = Object.keys(payload).join(",");
+    this.logTelegramAuthDebug(`attempt: authenticateWebApp keys=[${payloadKeys}] body=${this.stringifyForDebug(payload)}`);
 
     return new Promise<boolean>((resolve) => {
-      this.authService.authenticateWebApp(currentPayload)
+      this.authService.authenticateWebApp(payload)
         .subscribe({
           next: () => {
-            this.logTelegramAuthDebug(`success: authenticateWebApp payload#${index + 1}`);
+            this.logTelegramAuthDebug("success: authenticateWebApp");
             resolve(true);
           },
-          error: async (error) => {
+          error: (error) => {
             const status = typeof error?.status === "number" ? error.status : "unknown";
-            this.logTelegramAuthDebug(`failed: authenticateWebApp payload#${index + 1} status=${status}`);
-
-            if (status === 422) {
-              const nextResult = await this.authenticateTelegramWebAppRecursive(payloads, index + 1);
-              resolve(nextResult);
-              return;
-            }
-
+            this.logTelegramAuthDebug(`failed: authenticateWebApp status=${status}`);
             resolve(false);
           },
         });
     });
   }
 
-  private buildTelegramWebAppPayloads(tgWa: any): any[] {
-    const normalizedPayload = {
-      initData: tgWa?.initData,
+  private buildTelegramWebAppPayload(tgWa: any): any {
+    const resolvedInitData = this.resolveTelegramInitData(tgWa);
+    return {
+      initData: resolvedInitData,
+      initDataRaw: tgWa?.initData,
       initDataUnsafe: tgWa?.initDataUnsafe,
       version: tgWa?.version,
       platform: tgWa?.platform,
       ...tgWa?.initDataUnsafe,
     };
-
-    const initData = typeof tgWa?.initData === "string" ? tgWa.initData : "";
-    const normalizedInitData = initData.length > 16 ? initData : this.serializeInitDataUnsafe(tgWa?.initDataUnsafe);
-    const initDataUnsafe = tgWa?.initDataUnsafe ?? {};
-
-    return [
-      normalizedPayload,
-      {initData: normalizedInitData},
-      {init_data: normalizedInitData},
-      {tgWebAppData: normalizedInitData},
-      initDataUnsafe,
-    ].filter((payload) => Object.keys(payload).length > 0);
   }
 
-  private serializeInitDataUnsafe(initDataUnsafe: any): string {
-    if (!initDataUnsafe || typeof initDataUnsafe !== "object") {
-      return "";
+  private resolveTelegramInitData(tgWa: any): string {
+    const rawInitData = typeof tgWa?.initData === "string" ? tgWa.initData : "";
+    if (rawInitData.length > 16) {
+      return rawInitData;
     }
 
-    return Object.keys(initDataUnsafe)
-      .sort()
-      .map((key) => {
-        const value = initDataUnsafe[key];
-        if (value === undefined || value === null) {
-          return "";
-        }
+    const search = this.window?.location?.search ?? "";
+    const hash = this.window?.location?.hash ?? "";
+    const searchParams = new URLSearchParams(search);
+    const hashParams = new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash);
 
-        const serialized = typeof value === "object" ? JSON.stringify(value) : String(value);
-        return `${encodeURIComponent(key)}=${encodeURIComponent(serialized)}`;
-      })
-      .filter(Boolean)
-      .join("&");
+    const fromSearch = searchParams.get("tgWebAppData");
+    const fromHash = hashParams.get("tgWebAppData");
+    const candidate = fromSearch || fromHash;
+    if (candidate) {
+      this.logTelegramAuthDebug(`info: using tgWebAppData from url (length=${candidate.length})`);
+      return decodeURIComponent(candidate);
+    }
+
+    return rawInitData;
+  }
+
+  private stringifyForDebug(payload: any): string {
+    try {
+      return JSON.stringify(payload);
+    } catch {
+      return "[unserializable]";
+    }
   }
 
   private logTelegramAuthDebug(message: string) {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -411,11 +411,55 @@ export class HeaderComponent implements OnInit, OnDestroy {
     const fromHash = hashParams.get("tgWebAppData");
     const candidate = fromSearch || fromHash;
     if (candidate) {
-      this.logTelegramAuthDebug(`info: using tgWebAppData from url (length=${candidate.length})`);
-      return decodeURIComponent(candidate);
+      const reconstructed = this.reconstructTelegramInitData(searchParams, hashParams, candidate);
+      this.logTelegramAuthDebug(`info: using tgWebAppData from url (rawLength=${candidate.length}, reconstructedLength=${reconstructed.length})`);
+      return reconstructed;
     }
 
     return rawInitData;
+  }
+
+  private reconstructTelegramInitData(searchParams: URLSearchParams, hashParams: URLSearchParams, base: string): string {
+    const merged = new URLSearchParams();
+    const baseParams = new URLSearchParams(base);
+
+    baseParams.forEach((value, key) => merged.set(key, value));
+
+    const knownKeys = [
+      "query_id",
+      "user",
+      "receiver",
+      "chat",
+      "chat_type",
+      "chat_instance",
+      "start_param",
+      "can_send_after",
+      "auth_date",
+      "signature",
+      "hash",
+    ];
+
+    const mergedFrom = [searchParams, hashParams];
+    for (const key of knownKeys) {
+      const existing = merged.get(key);
+      if (existing) {
+        continue;
+      }
+
+      for (const source of mergedFrom) {
+        const value = source.get(key);
+        if (value) {
+          merged.set(key, value);
+          break;
+        }
+      }
+    }
+
+    const keysSet = new Set<string>();
+    merged.forEach((_, key) => keysSet.add(key));
+    const keys = Array.from(keysSet).sort();
+    this.logTelegramAuthDebug(`info: reconstructed initData keys=[${keys.join(",")}]`);
+    return merged.toString();
   }
 
   private stringifyForDebug(payload: any): string {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -335,6 +335,12 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   private async tryTelegramAuthWithTimeout(): Promise<boolean> {
+    const existingWebApp = this.getTelegramWebApp();
+    if (existingWebApp?.initData) {
+      this.logTelegramAuthDebug(`attempt: authenticate existing webapp (initDataLength=${existingWebApp.initData.length})`);
+      return this.authenticateTelegramWebApp(existingWebApp);
+    }
+
     if (!this.shouldTryTelegramSdkLoad()) {
       this.logTelegramAuthDebug("skip: no telegram markers in url/userAgent");
       return false;
@@ -349,25 +355,40 @@ export class HeaderComponent implements OnInit, OnDestroy {
       }
 
       this.logTelegramAuthDebug(`attempt: authenticate webapp (initDataLength=${tgWa.initData.length})`);
-      return await new Promise<boolean>((resolve) => {
-        this.authService.authenticateWebApp(tgWa)
-          .subscribe({
-            next: () => {
-              this.logTelegramAuthDebug("success: authenticateWebApp");
-              resolve(true);
-            },
-            error: (error) => {
-              const status = typeof error?.status === "number" ? error.status : "unknown";
-              this.logTelegramAuthDebug(`failed: authenticateWebApp status=${status}`);
-              resolve(false);
-            },
-          });
-      });
+      return this.authenticateTelegramWebApp(tgWa);
     } catch (error) {
       const message = error instanceof Error ? error.message : "unknown error";
       this.logTelegramAuthDebug(`failed: telegram sdk load error (${message})`);
       return false;
     }
+  }
+
+  private authenticateTelegramWebApp(tgWa: any): Promise<boolean> {
+    const payload = this.buildTelegramWebAppPayload(tgWa);
+    return new Promise<boolean>((resolve) => {
+      this.authService.authenticateWebApp(payload)
+        .subscribe({
+          next: () => {
+            this.logTelegramAuthDebug("success: authenticateWebApp");
+            resolve(true);
+          },
+          error: (error) => {
+            const status = typeof error?.status === "number" ? error.status : "unknown";
+            this.logTelegramAuthDebug(`failed: authenticateWebApp status=${status}`);
+            resolve(false);
+          },
+        });
+    });
+  }
+
+  private buildTelegramWebAppPayload(tgWa: any) {
+    return {
+      initData: tgWa?.initData,
+      initDataUnsafe: tgWa?.initDataUnsafe,
+      version: tgWa?.version,
+      platform: tgWa?.platform,
+      ...tgWa?.initDataUnsafe,
+    };
   }
 
   private logTelegramAuthDebug(message: string) {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -33,8 +33,8 @@ interface Countdown {
 })
 export class HeaderComponent implements OnInit, OnDestroy {
   private readonly window: (Window & typeof globalThis) | undefined;
-  private telegramSdkLoadPromise: Promise<void> | undefined;
-  private readonly forceTelegramSdkLoad = false;
+  private readonly tg: any;
+  private readonly tgWa: any;
   private countdownInterval: number | undefined;
   activeGame: ActiveGame | undefined;
   countdown: Countdown | undefined;
@@ -51,6 +51,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private themeService: ThemeService,
   ) {
     this.window = this._document.defaultView;
+    this.tg = (this.window as any)?.Telegram;
+    this.tgWa = this.tg?.WebApp;
   }
 
   openLoginForm() {
@@ -108,105 +110,27 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit() {
-    const telegramAuthResult = await this.tryTelegramAuthWithTimeout();
-    if (telegramAuthResult) {
-      await this.userService.loadMe();
-      this.getTelegramWebApp()?.ready?.();
-      return;
-    }
-
-    await this.userService.loadMe();
     this.selectedThemeMode = this.themeService.getMode();
     this.gamesService.getActiveGame().subscribe(game => {
       this.activeGame = game;
       this.countdown = this.getCountdown();
       this.setupCountdownTicker();
     });
-  }
 
-  private async tryTelegramAuthWithTimeout(): Promise<boolean> {
-    const existingWebApp = this.getTelegramWebApp();
-    if (existingWebApp?.initData) {
-      this.logTelegramAuthDebug(`attempt: authenticate existing webapp (initDataLength=${existingWebApp.initData.length})`);
-      return this.authenticateTelegramWebApp(existingWebApp);
-    }
-
-    try {
-      await this.loadTelegramSDK();
-      const tgWa = this.getTelegramWebApp();
-      if (!tgWa?.initData) {
-        this.logTelegramAuthDebug("skip: telegram sdk loaded but initData is empty");
-        return false;
+    if (this.tgWa?.initData) {
+      this.logTelegramAuthDebug(`attempt: authenticate blocking webapp (initDataLength=${this.tgWa.initData.length})`);
+      const telegramAuthResult = await this.authenticateTelegramWebApp(this.tgWa);
+      if (telegramAuthResult) {
+        await this.userService.loadMe();
+        this.tgWa?.ready?.();
+        return;
       }
-
-      this.logTelegramAuthDebug(`attempt: authenticate webapp (initDataLength=${tgWa.initData.length})`);
-      return this.authenticateTelegramWebApp(tgWa);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "unknown error";
-      this.logTelegramAuthDebug(`failed: telegram sdk load error (${message})`);
-      return false;
+    } else {
+      this.logTelegramAuthDebug("skip: blocking webapp is missing initData");
     }
+
+    await this.userService.loadMe();
   }
-
-  private async loadTelegramSDK(timeoutMs = 2500): Promise<void> {
-    if (!this.window) {
-      return;
-    }
-
-    if (this.getTelegramWebApp()) {
-      return;
-    }
-
-    if (this.telegramSdkLoadPromise) {
-      return this.telegramSdkLoadPromise;
-    }
-
-    this.telegramSdkLoadPromise = new Promise<void>((resolve, reject) => {
-      const src = "https://telegram.org/js/telegram-web-app.js";
-      const existingScript = this._document.querySelector(`script[src="${src}"]`) as HTMLScriptElement | null;
-      const script = existingScript ?? this._document.createElement("script");
-      let timeoutId: number | undefined;
-
-      const cleanup = () => {
-        if (timeoutId !== undefined) {
-          this.window?.clearTimeout(timeoutId);
-        }
-        script.onload = null;
-        script.onerror = null;
-      };
-
-      script.onload = () => {
-        cleanup();
-        resolve();
-      };
-
-      script.onerror = () => {
-        cleanup();
-        reject(new Error("Failed to load Telegram WebApp SDK"));
-      };
-
-      timeoutId = this.window?.setTimeout(() => {
-        cleanup();
-        reject(new Error("Telegram WebApp SDK load timeout"));
-      }, timeoutMs);
-
-      if (!existingScript) {
-        script.src = src;
-        script.async = true;
-        this._document.head.appendChild(script);
-      }
-    }).catch((error: unknown) => {
-      this.telegramSdkLoadPromise = undefined;
-      throw error;
-    });
-
-    return this.telegramSdkLoadPromise;
-  }
-
-  private getTelegramWebApp() {
-    return (this.window as any)?.Telegram?.WebApp;
-  }
-
 
   hasActiveGame() {
     return this.activeGame !== undefined;

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -33,8 +33,8 @@ interface Countdown {
 })
 export class HeaderComponent implements OnInit, OnDestroy {
   private readonly window: (Window & typeof globalThis) | undefined;
-  private readonly tg: any;
-  private readonly tgWa: any;
+  private telegramSdkLoadPromise: Promise<void> | undefined;
+  private readonly forceTelegramSdkLoad = false;
   private countdownInterval: number | undefined;
   activeGame: ActiveGame | undefined;
   countdown: Countdown | undefined;
@@ -51,8 +51,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private themeService: ThemeService,
   ) {
     this.window = this._document.defaultView;
-    this.tg = (this.window as any)?.Telegram;
-    this.tgWa = this.tg?.WebApp;
   }
 
   openLoginForm() {
@@ -110,27 +108,105 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   async ngOnInit() {
+    const telegramAuthResult = await this.tryTelegramAuthWithTimeout();
+    if (telegramAuthResult) {
+      await this.userService.loadMe();
+      this.getTelegramWebApp()?.ready?.();
+      return;
+    }
+
+    await this.userService.loadMe();
     this.selectedThemeMode = this.themeService.getMode();
     this.gamesService.getActiveGame().subscribe(game => {
       this.activeGame = game;
       this.countdown = this.getCountdown();
       this.setupCountdownTicker();
     });
+  }
 
-    if (this.tgWa?.initData) {
-      this.logTelegramAuthDebug(`attempt: authenticate blocking webapp (initDataLength=${this.tgWa.initData.length})`);
-      const telegramAuthResult = await this.authenticateTelegramWebApp(this.tgWa);
-      if (telegramAuthResult) {
-        await this.userService.loadMe();
-        this.tgWa?.ready?.();
-        return;
-      }
-    } else {
-      this.logTelegramAuthDebug("skip: blocking webapp is missing initData");
+  private async tryTelegramAuthWithTimeout(): Promise<boolean> {
+    const existingWebApp = this.getTelegramWebApp();
+    if (existingWebApp?.initData) {
+      this.logTelegramAuthDebug(`attempt: authenticate existing webapp (initDataLength=${existingWebApp.initData.length})`);
+      return this.authenticateTelegramWebApp(existingWebApp);
     }
 
-    await this.userService.loadMe();
+    try {
+      await this.loadTelegramSDK();
+      const tgWa = this.getTelegramWebApp();
+      if (!tgWa?.initData) {
+        this.logTelegramAuthDebug("skip: telegram sdk loaded but initData is empty");
+        return false;
+      }
+
+      this.logTelegramAuthDebug(`attempt: authenticate webapp (initDataLength=${tgWa.initData.length})`);
+      return this.authenticateTelegramWebApp(tgWa);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "unknown error";
+      this.logTelegramAuthDebug(`failed: telegram sdk load error (${message})`);
+      return false;
+    }
   }
+
+  private async loadTelegramSDK(timeoutMs = 2500): Promise<void> {
+    if (!this.window) {
+      return;
+    }
+
+    if (this.getTelegramWebApp()) {
+      return;
+    }
+
+    if (this.telegramSdkLoadPromise) {
+      return this.telegramSdkLoadPromise;
+    }
+
+    this.telegramSdkLoadPromise = new Promise<void>((resolve, reject) => {
+      const src = "https://telegram.org/js/telegram-web-app.js";
+      const existingScript = this._document.querySelector(`script[src="${src}"]`) as HTMLScriptElement | null;
+      const script = existingScript ?? this._document.createElement("script");
+      let timeoutId: number | undefined;
+
+      const cleanup = () => {
+        if (timeoutId !== undefined) {
+          this.window?.clearTimeout(timeoutId);
+        }
+        script.onload = null;
+        script.onerror = null;
+      };
+
+      script.onload = () => {
+        cleanup();
+        resolve();
+      };
+
+      script.onerror = () => {
+        cleanup();
+        reject(new Error("Failed to load Telegram WebApp SDK"));
+      };
+
+      timeoutId = this.window?.setTimeout(() => {
+        cleanup();
+        reject(new Error("Telegram WebApp SDK load timeout"));
+      }, timeoutMs);
+
+      if (!existingScript) {
+        script.src = src;
+        script.async = true;
+        this._document.head.appendChild(script);
+      }
+    }).catch((error: unknown) => {
+      this.telegramSdkLoadPromise = undefined;
+      throw error;
+    });
+
+    return this.telegramSdkLoadPromise;
+  }
+
+  private getTelegramWebApp() {
+    return (this.window as any)?.Telegram?.WebApp;
+  }
+
 
   hasActiveGame() {
     return this.activeGame !== undefined;

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -364,31 +364,82 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   private authenticateTelegramWebApp(tgWa: any): Promise<boolean> {
-    const payload = this.buildTelegramWebAppPayload(tgWa);
+    const payloads = this.buildTelegramWebAppPayloads(tgWa);
+    return this.authenticateTelegramWebAppRecursive(payloads, 0);
+  }
+
+  private authenticateTelegramWebAppRecursive(payloads: any[], index: number): Promise<boolean> {
+    if (index >= payloads.length) {
+      return Promise.resolve(false);
+    }
+
+    const currentPayload = payloads[index];
+    const payloadKeys = Object.keys(currentPayload).join(",");
+    this.logTelegramAuthDebug(`attempt: authenticateWebApp payload#${index + 1} keys=[${payloadKeys}]`);
+
     return new Promise<boolean>((resolve) => {
-      this.authService.authenticateWebApp(payload)
+      this.authService.authenticateWebApp(currentPayload)
         .subscribe({
           next: () => {
-            this.logTelegramAuthDebug("success: authenticateWebApp");
+            this.logTelegramAuthDebug(`success: authenticateWebApp payload#${index + 1}`);
             resolve(true);
           },
-          error: (error) => {
+          error: async (error) => {
             const status = typeof error?.status === "number" ? error.status : "unknown";
-            this.logTelegramAuthDebug(`failed: authenticateWebApp status=${status}`);
+            this.logTelegramAuthDebug(`failed: authenticateWebApp payload#${index + 1} status=${status}`);
+
+            if (status === 422) {
+              const nextResult = await this.authenticateTelegramWebAppRecursive(payloads, index + 1);
+              resolve(nextResult);
+              return;
+            }
+
             resolve(false);
           },
         });
     });
   }
 
-  private buildTelegramWebAppPayload(tgWa: any) {
-    return {
+  private buildTelegramWebAppPayloads(tgWa: any): any[] {
+    const normalizedPayload = {
       initData: tgWa?.initData,
       initDataUnsafe: tgWa?.initDataUnsafe,
       version: tgWa?.version,
       platform: tgWa?.platform,
       ...tgWa?.initDataUnsafe,
     };
+
+    const initData = typeof tgWa?.initData === "string" ? tgWa.initData : "";
+    const normalizedInitData = initData.length > 16 ? initData : this.serializeInitDataUnsafe(tgWa?.initDataUnsafe);
+    const initDataUnsafe = tgWa?.initDataUnsafe ?? {};
+
+    return [
+      normalizedPayload,
+      {initData: normalizedInitData},
+      {init_data: normalizedInitData},
+      {tgWebAppData: normalizedInitData},
+      initDataUnsafe,
+    ].filter((payload) => Object.keys(payload).length > 0);
+  }
+
+  private serializeInitDataUnsafe(initDataUnsafe: any): string {
+    if (!initDataUnsafe || typeof initDataUnsafe !== "object") {
+      return "";
+    }
+
+    return Object.keys(initDataUnsafe)
+      .sort()
+      .map((key) => {
+        const value = initDataUnsafe[key];
+        if (value === undefined || value === null) {
+          return "";
+        }
+
+        const serialized = typeof value === "object" ? JSON.stringify(value) : String(value);
+        return `${encodeURIComponent(key)}=${encodeURIComponent(serialized)}`;
+      })
+      .filter(Boolean)
+      .join("&");
   }
 
   private logTelegramAuthDebug(message: string) {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -1,6 +1,6 @@
 import {Component, Inject, OnDestroy, OnInit} from '@angular/core';
 import {FormsModule} from "@angular/forms";
-import {DOCUMENT, NgClass, NgStyle} from "@angular/common";
+import {DOCUMENT} from "@angular/common";
 import {AuthComponent} from "../auth/auth.component";
 import {AuthService} from "../auth/auth.service";
 import {UserService} from "../auth/user.service";
@@ -23,8 +23,6 @@ interface Countdown {
   standalone: true,
   imports: [
     AuthComponent,
-    NgClass,
-    NgStyle,
     RouterLink,
     RouterLinkActive,
     MatIcon,
@@ -263,12 +261,11 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   private authenticateTelegramWebApp(tgWa: any): Promise<boolean> {
-    const payload = this.buildTelegramWebAppPayload(tgWa);
-    const payloadKeys = Object.keys(payload).join(",");
-    this.logTelegramAuthDebug(`attempt: authenticateWebApp keys=[${payloadKeys}] body=${this.stringifyForDebug(payload)}`);
+    const payloadKeys = Object.keys(tgWa).join(",");
+    this.logTelegramAuthDebug(`attempt: authenticateWebApp keys=[${payloadKeys}] body=${this.stringifyForDebug(tgWa)}`);
 
     return new Promise<boolean>((resolve) => {
-      this.authService.authenticateWebApp(payload)
+      this.authService.authenticateWebApp(tgWa)
         .subscribe({
           next: () => {
             this.logTelegramAuthDebug("success: authenticateWebApp");
@@ -281,84 +278,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
           },
         });
     });
-  }
-
-  private buildTelegramWebAppPayload(tgWa: any): any {
-    const resolvedInitData = this.resolveTelegramInitData(tgWa);
-    return {
-      initData: resolvedInitData,
-      initDataRaw: tgWa?.initData,
-      initDataUnsafe: tgWa?.initDataUnsafe,
-      version: tgWa?.version,
-      platform: tgWa?.platform,
-      ...tgWa?.initDataUnsafe,
-    };
-  }
-
-  private resolveTelegramInitData(tgWa: any): string {
-    const rawInitData = typeof tgWa?.initData === "string" ? tgWa.initData : "";
-    if (rawInitData.length > 16) {
-      return rawInitData;
-    }
-
-    const search = this.window?.location?.search ?? "";
-    const hash = this.window?.location?.hash ?? "";
-    const searchParams = new URLSearchParams(search);
-    const hashParams = new URLSearchParams(hash.startsWith("#") ? hash.slice(1) : hash);
-
-    const fromSearch = searchParams.get("tgWebAppData");
-    const fromHash = hashParams.get("tgWebAppData");
-    const candidate = fromSearch || fromHash;
-    if (candidate) {
-      const reconstructed = this.reconstructTelegramInitData(searchParams, hashParams, candidate);
-      this.logTelegramAuthDebug(`info: using tgWebAppData from url (rawLength=${candidate.length}, reconstructedLength=${reconstructed.length})`);
-      return reconstructed;
-    }
-
-    return rawInitData;
-  }
-
-  private reconstructTelegramInitData(searchParams: URLSearchParams, hashParams: URLSearchParams, base: string): string {
-    const merged = new URLSearchParams();
-    const baseParams = new URLSearchParams(base);
-
-    baseParams.forEach((value, key) => merged.set(key, value));
-
-    const knownKeys = [
-      "query_id",
-      "user",
-      "receiver",
-      "chat",
-      "chat_type",
-      "chat_instance",
-      "start_param",
-      "can_send_after",
-      "auth_date",
-      "signature",
-      "hash",
-    ];
-
-    const mergedFrom = [searchParams, hashParams];
-    for (const key of knownKeys) {
-      const existing = merged.get(key);
-      if (existing) {
-        continue;
-      }
-
-      for (const source of mergedFrom) {
-        const value = source.get(key);
-        if (value) {
-          merged.set(key, value);
-          break;
-        }
-      }
-    }
-
-    const keysSet = new Set<string>();
-    merged.forEach((_, key) => keysSet.add(key));
-    const keys = Array.from(keysSet).sort();
-    this.logTelegramAuthDebug(`info: reconstructed initData keys=[${keys.join(",")}]`);
-    return merged.toString();
   }
 
   private stringifyForDebug(payload: any): string {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -35,8 +35,8 @@ interface Countdown {
 })
 export class HeaderComponent implements OnInit, OnDestroy {
   private readonly window: (Window & typeof globalThis) | undefined;
-  private telegramSdkLoadPromise: Promise<void> | undefined;
-  private readonly forceTelegramSdkLoad = false;
+  private readonly tg: any;
+  private readonly tgWa: any;
   private countdownInterval: number | undefined;
   activeGame: ActiveGame | undefined;
   countdown: Countdown | undefined;
@@ -53,6 +53,8 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private themeService: ThemeService,
   ) {
     this.window = this._document.defaultView;
+    this.tg = (this.window as any)?.Telegram;
+    this.tgWa = this.tg?.WebApp;
   }
 
   openLoginForm() {
@@ -117,15 +119,16 @@ export class HeaderComponent implements OnInit, OnDestroy {
       this.setupCountdownTicker();
     });
 
-    if (!this.window) {
-      return;
-    }
-
-    const telegramAuthResult = await this.tryTelegramAuthWithTimeout();
-    if (telegramAuthResult) {
-      await this.userService.loadMe();
-      this.getTelegramWebApp()?.ready?.();
-      return;
+    if (this.tgWa?.initData) {
+      this.logTelegramAuthDebug(`attempt: authenticate blocking webapp (initDataLength=${this.tgWa.initData.length})`);
+      const telegramAuthResult = await this.authenticateTelegramWebApp(this.tgWa);
+      if (telegramAuthResult) {
+        await this.userService.loadMe();
+        this.tgWa?.ready?.();
+        return;
+      }
+    } else {
+      this.logTelegramAuthDebug("skip: blocking webapp is missing initData");
     }
 
     await this.userService.loadMe();
@@ -257,110 +260,6 @@ export class HeaderComponent implements OnInit, OnDestroy {
       secondValue: seconds,
       secondUnit: "seconds",
     };
-  }
-
-  private getTelegramWebApp() {
-    return (this.window as any)?.Telegram?.WebApp;
-  }
-
-  private shouldTryTelegramSdkLoad(): boolean {
-    if (!this.window) {
-      return false;
-    }
-
-    const search = this.window.location.search ?? "";
-    const hash = this.window.location.hash ?? "";
-    const userAgent = this.window.navigator?.userAgent ?? "";
-
-    const hasTelegramMarkers = ["tgWebAppData", "hash", "auth_date"]
-      .some(marker => search.includes(marker) || hash.includes(marker));
-    const isTelegramUserAgent = userAgent.includes("Telegram");
-
-    return hasTelegramMarkers || isTelegramUserAgent || this.forceTelegramSdkLoad;
-  }
-
-  private async loadTelegramSDK(timeoutMs = 2500): Promise<void> {
-    if (!this.window) {
-      return;
-    }
-
-    if (this.getTelegramWebApp()) {
-      return;
-    }
-
-    if (this.telegramSdkLoadPromise) {
-      return this.telegramSdkLoadPromise;
-    }
-
-    this.telegramSdkLoadPromise = new Promise<void>((resolve, reject) => {
-      const src = "https://telegram.org/js/telegram-web-app.js";
-      const existingScript = this._document.querySelector(`script[src="${src}"]`) as HTMLScriptElement | null;
-      const script = existingScript ?? this._document.createElement("script");
-      let timeoutId: number | undefined;
-
-      const cleanup = () => {
-        if (timeoutId !== undefined) {
-          this.window?.clearTimeout(timeoutId);
-        }
-        script.onload = null;
-        script.onerror = null;
-      };
-
-      script.onload = () => {
-        cleanup();
-        resolve();
-      };
-
-      script.onerror = () => {
-        cleanup();
-        reject(new Error("Failed to load Telegram WebApp SDK"));
-      };
-
-      timeoutId = this.window?.setTimeout(() => {
-        cleanup();
-        reject(new Error("Telegram WebApp SDK load timeout"));
-      }, timeoutMs);
-
-      if (!existingScript) {
-        script.src = src;
-        script.async = true;
-        this._document.head.appendChild(script);
-      }
-    }).catch((error: unknown) => {
-      this.telegramSdkLoadPromise = undefined;
-      throw error;
-    });
-
-    return this.telegramSdkLoadPromise;
-  }
-
-  private async tryTelegramAuthWithTimeout(): Promise<boolean> {
-    const existingWebApp = this.getTelegramWebApp();
-    if (existingWebApp?.initData) {
-      this.logTelegramAuthDebug(`attempt: authenticate existing webapp (initDataLength=${existingWebApp.initData.length})`);
-      return this.authenticateTelegramWebApp(existingWebApp);
-    }
-
-    if (!this.shouldTryTelegramSdkLoad()) {
-      this.logTelegramAuthDebug("skip: no telegram markers in url/userAgent");
-      return false;
-    }
-
-    try {
-      await this.loadTelegramSDK();
-      const tgWa = this.getTelegramWebApp();
-      if (!tgWa?.initData) {
-        this.logTelegramAuthDebug("skip: telegram sdk loaded but initData is empty");
-        return false;
-      }
-
-      this.logTelegramAuthDebug(`attempt: authenticate webapp (initDataLength=${tgWa.initData.length})`);
-      return this.authenticateTelegramWebApp(tgWa);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : "unknown error";
-      this.logTelegramAuthDebug(`failed: telegram sdk load error (${message})`);
-      return false;
-    }
   }
 
   private authenticateTelegramWebApp(tgWa: any): Promise<boolean> {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -261,8 +261,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   private authenticateTelegramWebApp(tgWa: any): Promise<boolean> {
-    const payloadKeys = Object.keys(tgWa).join(",");
-    this.logTelegramAuthDebug(`attempt: authenticateWebApp keys=[${payloadKeys}] body=${this.stringifyForDebug(tgWa)}`);
+    this.logTelegramAuthDebug(`attempt: authenticateWebApp ${this.stringifyForDebug(tgWa)}`);
 
     return new Promise<boolean>((resolve) => {
       this.authService.authenticateWebApp(tgWa)
@@ -281,11 +280,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   private stringifyForDebug(payload: any): string {
-    try {
-      return JSON.stringify(payload);
-    } catch {
-      return "[unserializable]";
-    }
+    return "disabled debug"
   }
 
   private logTelegramAuthDebug(message: string) {

--- a/src/app/version/version.service.ts
+++ b/src/app/version/version.service.ts
@@ -6,9 +6,7 @@ import {ShvatkaConfig} from "../app.config";
 
 export interface VersionInfo {
   vcs_hash?: string;
-  vcs_ref?: string;
-  vcs_branch?: string;
-  vcs_tag?: string;
+  vcs_name?: string;
   commit_at?: string;
   build_at?: string;
 }

--- a/src/app/version/version.service.ts
+++ b/src/app/version/version.service.ts
@@ -1,0 +1,35 @@
+import {Injectable} from "@angular/core";
+import {HttpClient} from "@angular/common/http";
+import {Observable, of} from "rxjs";
+import {catchError} from "rxjs/operators";
+import {ShvatkaConfig} from "../app.config";
+
+export interface VersionInfo {
+  vcs_hash?: string;
+  vcs_ref?: string;
+  vcs_branch?: string;
+  vcs_tag?: string;
+  commit_at?: string;
+  build_at?: string;
+}
+
+@Injectable({
+  providedIn: "root",
+})
+export class VersionService {
+  constructor(
+    private http: HttpClient,
+    private config: ShvatkaConfig,
+  ) {
+  }
+
+  getBackendVersion(): Observable<VersionInfo | undefined> {
+    return this.http.get<VersionInfo>(`${this.config.apiUrl}/version`)
+      .pipe(catchError(() => of(undefined)));
+  }
+
+  getFrontendVersion(): Observable<VersionInfo | undefined> {
+    return this.http.get<VersionInfo>("/assets/frontend-version.json")
+      .pipe(catchError(() => of(undefined)));
+  }
+}

--- a/src/assets/frontend-version.json
+++ b/src/assets/frontend-version.json
@@ -1,0 +1,8 @@
+{
+  "vcs_hash": "unknown",
+  "vcs_ref": "",
+  "vcs_branch": "",
+  "vcs_tag": "",
+  "commit_at": "",
+  "build_at": ""
+}

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,6 @@
   <title>Shvatka</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <!-- Load environment variables -->
   <script src="assets/env.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,7 @@
   <title>Shvatka</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <script src="https://telegram.org/js/telegram-web-app.js"></script>
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <!-- Load environment variables -->
   <script src="assets/env.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,20 @@
   <title>Shvatka</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <script src="https://telegram.org/js/telegram-web-app.js"></script>
+  <script>
+    (function () {
+      const params = new URLSearchParams(window.location.search);
+      const isTg = params.get('tg') === 'true';
+      if (isTg) {
+        const script = document.createElement('script');
+        script.src = 'https://telegram.org/js/telegram-web-app.js';
+        script.async = false;
+        const firstScript = document.getElementsByTagName('script')[0];
+        firstScript.parentNode.insertBefore(script, firstScript);
+      }
+    })();
+  </script>
+
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <!-- Load environment variables -->
   <script src="assets/env.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -13,7 +13,7 @@
         const script = document.createElement('script');
         script.src = 'https://telegram.org/js/telegram-web-app.js';
         script.async = false;
-        const firstScript = document.getElementsByTagName('script')[0];
+        const firstScript = document.getElementsByTagName('link')[0];
         firstScript.parentNode.insertBefore(script, firstScript);
       }
     })();

--- a/src/index.html
+++ b/src/index.html
@@ -7,15 +7,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>
     (function () {
-      window.alert("started");
       const params = new URLSearchParams(window.location.search);
       const isTg = params.get('tg') === 'true';
-      window.alert("isTg=" + isTg);
       if (isTg) {
         const script = document.createElement('script');
         script.src = 'https://telegram.org/js/telegram-web-app.js';
         script.async = false;
-        const firstScript = document.getElementsByTagName('link')[0];
+        const firstScript = document.getElementsByTagName('script')[0];
         firstScript.parentNode.insertBefore(script, firstScript);
       }
     })();

--- a/src/index.html
+++ b/src/index.html
@@ -7,8 +7,10 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <script>
     (function () {
+      window.alert("started");
       const params = new URLSearchParams(window.location.search);
       const isTg = params.get('tg') === 'true';
+      window.alert("isTg=" + isTg);
       if (isTg) {
         const script = document.createElement('script');
         script.src = 'https://telegram.org/js/telegram-web-app.js';


### PR DESCRIPTION
### Motivation
- The quick unauthenticated response from the normal `/users/me` load could win the previous race and prevent Telegram instant auth in the in-app (mini) browser. 
- The Telegram in-app browser lacks devtools, so additional in-app debug visibility is required to investigate auth failures.

### Description
- Try Telegram WebApp auth first in `HeaderComponent.ngOnInit` and only fall back to `this.userService.loadMe()` if Telegram auth is unavailable or fails. 
- Add detailed debug traces in `tryTelegramAuthWithTimeout` for skip reasons, SDK load attempts, `initData` absence, auth attempts, auth HTTP failures (status logged), and SDK load exceptions. 
- Add `logTelegramAuthDebug` helper that emits `console.info` lines and appends the last 40 lines to `sessionStorage` under the key `tg-auth-debug-log` so logs are accessible inside the Telegram in-app browser. 
- Modified file: `src/app/header/header.component.ts`.

### Testing
- Ran the production build with `npm run build` which completed successfully. 
- Angular bundle budget warnings were reported but are unchanged and unrelated to this fix. 
- No additional automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee1e65809c832a90b7d95dd878d9d6)