### PR TITLE
Add hero image to home start page

### DIFF
--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,4 +1,15 @@
 <section class="home">
-  <h1>Добро пожаловать в Shvatka</h1>
-  <p>Следите за активной игрой, просматривайте сценарии и проверяйте результаты в адаптивном интерфейсе.</p>
+  <div class="main-info">
+    <img
+      ngSrc="assets/icons/web-app-manifest-512x512.png"
+      alt="Логотип"
+      width="512"
+      height="512"
+      class="side-image"
+    />
+    <span class="text-content">
+    <h1>Добро пожаловать в Shvatka</h1>
+    <p>Следите за активной игрой, просматривайте сценарии и проверяйте результаты в адаптивном интерфейсе.</p>
+    </span>
+  </div>
 </section>

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -1,11 +1,43 @@
 .home {
   text-align: center;
   padding: clamp(1rem, 3vw, 2rem);
+  display: grid;
+  justify-items: center;
+  gap: 1rem;
+}
+
+.main-info {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.side-image {
+  width: min(70vw, 320px);
+  height: auto;
+  object-fit: cover;
+  border-radius: 24%;
+  box-shadow: 0 12px 28px rgb(0 0 0 / 45%);
+}
+
+.text-content {
+  flex: 1;
+}
+@media (max-width: 768px) {
+  .main-info {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .side-image {
+    width: 100%;
+    max-width: 300px;
+  }
 }
 
 h1 {
-  margin-top: 0;
-  margin-bottom: 0.75rem;
+  margin: 0;
 }
 
 p {

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,9 +1,12 @@
 import {Component} from '@angular/core';
+import {NgOptimizedImage} from "@angular/common";
 
 @Component({
   selector: 'app-home',
   standalone: true,
-  imports: [],
+  imports: [
+    NgOptimizedImage
+  ],
   templateUrl: './home.component.html',
   styleUrl: './home.component.scss'
 })


### PR DESCRIPTION
### Motivation
- Make the home/start page more welcoming and visually descriptive by adding a hero image and aligning content for better presentation.

### Description
- Added an `<img>` hero to `src/app/home/home.component.html` using the existing `assets/icons/web-app-manifest-512x512.png` with `alt`, `width`, and `height`, and updated `src/app/home/home.component.scss` to center the layout, add a `.home-hero` rule (responsive width, rounded corners, shadow) and simplify `h1` margins.

### Testing
- Ran `npm run build`, which completed successfully (Angular reported bundle size warnings but the build passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f513d17280832a9ca6146b701abde6)