### PR TITLE
Add events spoiler to current gameplay hints

### DIFF
--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -96,6 +96,37 @@
         </li>
       }
     </ul>
+
+    @if (hasAnyEvents()) {
+      <details class="events-spoiler">
+        <summary>Последние игровые события</summary>
+
+        @if (getCurrentLevelEvents().length > 0) {
+          <ul class="events-list">
+            @for (event of getCurrentLevelEvents(); track event.id) {
+              <li class="event-entry">
+                <strong>{{ toLocal(event.at) }}</strong>
+                <app-effects-part [effects]="event.effects" [gameId]="getCurrentHints()!.game_id"></app-effects-part>
+              </li>
+            }
+          </ul>
+        }
+
+        @if (getPreviousLevelEvents().length > 0) {
+          <details class="events-spoiler events-spoiler-nested">
+            <summary>События прошлых уровней</summary>
+            <ul class="events-list">
+              @for (event of getPreviousLevelEvents(); track event.id) {
+                <li class="event-entry">
+                  <strong>{{ toLocal(event.at) }}</strong>
+                  <app-effects-part [effects]="event.effects" [gameId]="getCurrentHints()!.game_id"></app-effects-part>
+                </li>
+              }
+            </ul>
+          </details>
+        }
+      </details>
+    }
   </div>
 }
 

--- a/src/app/game_play/game_play.component.scss
+++ b/src/app/game_play/game_play.component.scss
@@ -324,3 +324,26 @@ td {
   justify-content: space-between;
   align-items: center;
 }
+
+.events-spoiler {
+  margin: 14px 0;
+}
+
+.events-spoiler summary {
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.events-spoiler-nested {
+  margin-top: 10px;
+  margin-left: 16px;
+}
+
+.events-list {
+  margin: 8px 0 0;
+  padding-left: 1.1rem;
+}
+
+.event-entry {
+  margin-bottom: 10px;
+}

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -5,6 +5,7 @@ import {
   TypedKeyResult,
   KeyEffect,
   TypedKeyLog,
+  GameEvent,
   CurrentWaivers,
   WaiversTeam,
   WaiverEntry,
@@ -330,6 +331,30 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     return effects
       .flatMap((effect: KeyEffect) => this.getEffectTags(effect))
       .filter((tag, idx, arr) => arr.indexOf(tag) === idx);
+  }
+
+
+
+  getCurrentLevelEvents(): GameEvent[] {
+    const hints = this.getCurrentHints();
+    if (!hints?.events) {
+      return [];
+    }
+
+    return hints.events.filter(event => event.level_time_id === hints.level_time_id);
+  }
+
+  getPreviousLevelEvents(): GameEvent[] {
+    const hints = this.getCurrentHints();
+    if (!hints?.events) {
+      return [];
+    }
+
+    return hints.events.filter(event => event.level_time_id !== hints.level_time_id);
+  }
+
+  hasAnyEvents(): boolean {
+    return this.getCurrentLevelEvents().length > 0 || this.getPreviousLevelEvents().length > 0;
   }
 
   hasAnyTypedKeys(): boolean {

--- a/src/app/game_play/game_play.service.ts
+++ b/src/app/game_play/game_play.service.ts
@@ -10,11 +10,21 @@ export type TypedKeyLog = KeyTime & {
   effects?: KeyEffect[];
 };
 
+export type GameEvent = {
+  id: number;
+  team_id: number;
+  level_time_id: number;
+  at: string;
+  effects?: KeyEffect[] | KeyEffect;
+};
+
 export class CurrentHints {
   constructor(
     public hints: TimeHint[],
     public typed_keys: TypedKeyLog[],
+    public events: GameEvent[],
     public level_number: number,
+    public level_time_id: number,
     public started_at: string,
     public game_id: number,
   ) {


### PR DESCRIPTION
### Motivation
- Surface recent game events alongside hints so players can see the last in-game effects and timings. 
- Distinguish events that belong to the current `level_time_id` from older events to avoid mixing past-level activity with the current level.

### Description
- Added `GameEvent` type and extended `CurrentHints` to include `events` and `level_time_id` to match backend response fields (`src/app/game_play/game_play.service.ts`).
- Implemented component helpers `getCurrentLevelEvents()`, `getPreviousLevelEvents()` and `hasAnyEvents()` to filter events by `level_time_id` (`src/app/game_play/game_play.component.ts`).
- Rendered a spoiler block under hints titled `Последние игровые события` that shows event time via `toLocal(event.at)` and event effects using the existing `<app-effects-part>` component, and added a nested spoiler `События прошлых уровней` for events with a different `level_time_id` (`src/app/game_play/game_play.component.html`).
- Added styling for the events spoiler, nested spoiler and event entries (`src/app/game_play/game_play.component.scss`).

### Testing
- Ran `npm run -s build` and the build completed successfully with no errors (there are pre-existing bundle/style budget warnings). 
- Verified the app compiles after changes and no runtime type/build errors were produced during the build step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa4dabef1c832a863e3dec2a7eec67)