### PR TITLE
Add one-time-token login callback component and route

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import {HomeComponent} from "./home/home.component";
 import {GameComponent} from "./game/game.component";
 import {GamePlayComponent} from "./game_play/game_play.component";
 import {ProfileComponent} from "./profile/profile.component";
+import {OneTimeTokenComponent} from "./auth/one-time-token.component";
 
 
 export const routes: Routes = [
@@ -12,4 +13,5 @@ export const routes: Routes = [
   {path: "games/running", component: GamePlayComponent},
   {path: "games/:id", component: GameComponent},
   {path: "profile", component: ProfileComponent},
+  {path: "auth/one-time-token", component: OneTimeTokenComponent},
 ];

--- a/src/app/auth/auth.service.ts
+++ b/src/app/auth/auth.service.ts
@@ -22,6 +22,14 @@ export class AuthService {
     )
   }
 
+
+  loginWithOneTimeToken(token: string) {
+    return this.http.postWithoutCookies<any>(
+      '/auth/one-time-token',
+      {token},
+    );
+  }
+
   public authenticate(user: any) {
     return this.http.postWithoutCookies("/auth/login/data", user)
   }

--- a/src/app/auth/one-time-token.component.html
+++ b/src/app/auth/one-time-token.component.html
@@ -1,0 +1,3 @@
+<div class="one-time-token-status">
+  Signing you in...
+</div>

--- a/src/app/auth/one-time-token.component.scss
+++ b/src/app/auth/one-time-token.component.scss
@@ -1,0 +1,5 @@
+.one-time-token-status {
+  text-align: center;
+  padding: 32px 16px;
+  font-size: 1.1rem;
+}

--- a/src/app/auth/one-time-token.component.ts
+++ b/src/app/auth/one-time-token.component.ts
@@ -1,0 +1,50 @@
+import {Component, OnInit} from '@angular/core';
+import {AuthService} from './auth.service';
+import {UserService} from './user.service';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {ActivatedRoute, Router} from '@angular/router';
+import {HttpErrorResponse} from '@angular/common/http';
+
+@Component({
+  selector: 'app-one-time-token',
+  standalone: true,
+  templateUrl: './one-time-token.component.html',
+  styleUrl: './one-time-token.component.scss'
+})
+export class OneTimeTokenComponent implements OnInit {
+  constructor(
+    private authService: AuthService,
+    private userService: UserService,
+    private route: ActivatedRoute,
+    private router: Router,
+    private snackBar: MatSnackBar,
+  ) {
+  }
+
+  ngOnInit(): void {
+    const token = this.route.snapshot.queryParamMap.get('token');
+    const next = this.route.snapshot.queryParamMap.get('next') || '/';
+
+    if (!token) {
+      this.snackBar.open('Missing one-time token', 'ok');
+      this.router.navigateByUrl('/');
+      return;
+    }
+
+    this.authService.loginWithOneTimeToken(token)
+      .subscribe({
+        next: async () => {
+          await this.userService.loadMe();
+          await this.router.navigateByUrl(next);
+        },
+        error: (err) => {
+          if (err instanceof HttpErrorResponse && err.status === 401) {
+            this.snackBar.open('Invalid or expired one-time token', 'ok');
+          } else {
+            this.snackBar.open('Authentication failed', 'ok');
+          }
+          this.router.navigateByUrl('/');
+        },
+      });
+  }
+}


### PR DESCRIPTION
### Motivation
- Support a one-time-token login flow where the frontend accepts `token` in the URL, posts it to the backend, and then either receives an auth cookie or an error and proceeds to load the user and continue navigation.

### Description
- Added `AuthService.loginWithOneTimeToken(token: string)` which posts `{token}` to `POST /auth/one-time-token` using `postWithoutCookies`.
- Introduced a new standalone `OneTimeTokenComponent` that reads `token` and optional `next` from query params, posts the token to the backend, calls `UserService.loadMe()` on success, and navigates to `next` (default `/`).
- The component shows a minimal `Signing you in...` UI and user-facing snackbars for missing, invalid/expired, or other authentication errors.
- Registered the new route `auth/one-time-token` in the application routes.

### Testing
- Ran `npm run build`, which completed successfully (Angular build succeeded; only existing bundle/style size budget warnings were reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcd9f1a9f4832a864970eba74d1ff3)