### PR TITLE
Skip default user bootstrap on one-time-token callback page

### DIFF
--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -117,6 +117,11 @@ export class HeaderComponent implements OnInit, OnDestroy {
       this.setupCountdownTicker();
     });
 
+    const currentPath = this.router.url.split('?')[0];
+    if (currentPath === '/auth/one-time-token') {
+      return;
+    }
+
     if (this.tgWa?.initData) {
       this.logDebugInfo(`attempt: authenticate blocking webapp (initDataLength=${this.tgWa.initData.length})`);
       const telegramAuthResult = await this.authenticateTelegramWebApp(this.tgWa);


### PR DESCRIPTION
### Motivation
- The header component's init flow called `UserService.loadMe()` on every page, which raced with the one-time-token exchange and caused an early `/users/me` request before the token exchange completed.

### Description
- Added an early return in `HeaderComponent.ngOnInit()` to skip the bootstrap auth flow when the current path is the one-time-token callback (`/auth/one-time-token`), implemented in `src/app/header/header.component.ts`.

### Testing
- Ran `npm run build` and the build completed successfully (existing Angular bundle budget warnings remain and are unchanged).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd79152c2c832ab97b8582881d881f)