### PR TITLE
Rework auth gating and backend error presentation

### DIFF
--- a/src/app/auth/auth-state.service.ts
+++ b/src/app/auth/auth-state.service.ts
@@ -1,0 +1,28 @@
+import {Injectable} from "@angular/core";
+
+@Injectable({
+  providedIn: "root",
+})
+export class AuthStateService {
+  private authenticated: boolean | undefined = undefined;
+
+  setAuthenticated() {
+    this.authenticated = true;
+  }
+
+  setUnauthenticated() {
+    this.authenticated = false;
+  }
+
+  reset() {
+    this.authenticated = undefined;
+  }
+
+  isAuthenticated(): boolean {
+    return this.authenticated === true;
+  }
+
+  isUnauthenticated(): boolean {
+    return this.authenticated === false;
+  }
+}

--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -37,7 +37,12 @@ export class AuthComponent implements AfterViewInit, OnInit {
   login(username: string | undefined, password: string | undefined) {
       this.authService.login(username!, password!)
         .subscribe({
-          next: () => {this.updateUser().then(() => this.closeLoginForm())},
+          next: () => {
+            this.updateUser().then(() => {
+              this.closeLoginForm();
+              window.location.reload();
+            })
+          },
           error: (err) => {
             if (err instanceof HttpErrorResponse && err.status === 401) {
               console.error("auth error " + err.message);

--- a/src/app/auth/user.service.ts
+++ b/src/app/auth/user.service.ts
@@ -2,6 +2,8 @@ import {Injectable} from "@angular/core";
 import {HttpAdapter} from "../http/http.adapter";
 import {HttpErrorResponse} from "@angular/common/http";
 import {Observable} from "rxjs";
+import {AuthService} from "./auth.service";
+import {AuthStateService} from "./auth-state.service";
 
 export class UserData {
   id: number | undefined;
@@ -13,19 +15,31 @@ export class UserData {
 })
 export class UserService {
   private me: UserData | undefined;
-  constructor(private http: HttpAdapter) {
+  constructor(
+    private http: HttpAdapter,
+    private authService: AuthService,
+    private authStateService: AuthStateService,
+  ) {
   }
   public loadMe(){
     return new Promise<UserData | undefined>(resolve =>
       this.http.get<UserData>('/users/me')
         .subscribe({
-          next: u => {this.me = u; resolve(u)},
+          next: u => {
+            this.me = u;
+            this.authStateService.setAuthenticated();
+            resolve(u)
+          },
           error: err => {
-            if (err instanceof HttpErrorResponse && err.status === 401) {
-              console.log("no saved user credentials")
+            if (err instanceof HttpErrorResponse && (err.status === 401 || err.status === 404)) {
+              console.log("no saved user credentials");
+              this.me = undefined;
+              this.authStateService.setUnauthenticated();
+              this.authService.showLoginForm();
               resolve(undefined);
               return;
             }
+            this.authStateService.reset();
             resolve(undefined);
           }
         })
@@ -42,6 +56,7 @@ export class UserService {
 
   public clearUser() {
     this.me = undefined;
+    this.authStateService.setUnauthenticated();
   }
 
   public changePassword(newPassword: string): Observable<void> {

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -3,7 +3,7 @@
 }
 
 @if (!isLoading() && isAuthRequired()) {
-  <p class="status-message">Для просмотра текущей игры нужно войти в аккаунт.</p>
+  <p class="status-message">Войди, чтобы играть.</p>
 }
 
 @if (hasHints()) {

--- a/src/app/game_play/game_play.service.ts
+++ b/src/app/game_play/game_play.service.ts
@@ -186,6 +186,12 @@ export class GamePlayService {
           return;
         }
 
+        if (!role) {
+          this.authRequired = true;
+          this.loadWaivers();
+          return;
+        }
+
         this.currentHints = undefined;
         this.isHintsLoading = false;
       });
@@ -263,6 +269,7 @@ export class GamePlayService {
             this.myRole = undefined;
             this.myRoleGameId = undefined;
             this.myRoleCacheUntil = undefined;
+            this.authRequired = true;
             onLoaded?.(undefined);
             return;
           }

--- a/src/app/games/games.component.html
+++ b/src/app/games/games.component.html
@@ -1,8 +1,17 @@
 <ul class="games-list">
   @for (game of getGames(); track game.id) {
-    <li class="games-list-item"><a routerLink="{{game.id}}" routerLinkActive="active" ariaCurrentWhenActive="page" (click)="onGameClick($event)">
-      <div class="game-number"><span>{{game.number}}</span></div>
-      <div class="game-name"><span>{{game.name}}</span></div>
-    </a></li>
+    <li class="games-list-item" [class.games-list-item-disabled]="!canOpenGame()">
+      @if (canOpenGame()) {
+        <a routerLink="{{game.id}}" routerLinkActive="active" ariaCurrentWhenActive="page">
+          <div class="game-number"><span>{{game.number}}</span></div>
+          <div class="game-name"><span>{{game.name}}</span></div>
+        </a>
+      } @else {
+        <button type="button" class="disabled-game-link" (click)="onGameClick($event)">
+          <div class="game-number"><span>{{game.number}}</span></div>
+          <div class="game-name"><span>{{game.name}}</span></div>
+        </button>
+      }
+    </li>
   }
 </ul>

--- a/src/app/games/games.component.html
+++ b/src/app/games/games.component.html
@@ -1,6 +1,6 @@
 <ul class="games-list">
   @for (game of getGames(); track game.id) {
-    <li class="games-list-item"><a routerLink="{{game.id}}" routerLinkActive="active" ariaCurrentWhenActive="page">
+    <li class="games-list-item"><a routerLink="{{game.id}}" routerLinkActive="active" ariaCurrentWhenActive="page" (click)="onGameClick($event)">
       <div class="game-number"><span>{{game.number}}</span></div>
       <div class="game-name"><span>{{game.name}}</span></div>
     </a></li>

--- a/src/app/games/games.component.scss
+++ b/src/app/games/games.component.scss
@@ -28,6 +28,24 @@
   padding: 0.8rem;
 }
 
+.disabled-game-link {
+  border: none;
+  width: 100%;
+  background: transparent;
+  color: var(--app-text);
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.8rem;
+  text-align: left;
+  cursor: not-allowed;
+}
+
+.games-list-item-disabled {
+  opacity: 0.8;
+}
+
 .game-number {
   background: #e7f7ec;
   color: #17603a;

--- a/src/app/games/games.component.ts
+++ b/src/app/games/games.component.ts
@@ -1,6 +1,8 @@
 import {Component, OnInit} from '@angular/core';
 import {Game, GamesService} from "./games.service";
 import {ActivatedRoute, Params, Router, RouterLink, RouterLinkActive} from "@angular/router";
+import {UserService} from "../auth/user.service";
+import {MatSnackBar} from "@angular/material/snack-bar";
 
 
 @Component({
@@ -18,6 +20,8 @@ export class GamesComponent implements OnInit {
     private gamesService: GamesService,
     private activatedRoute: ActivatedRoute,
     private router: Router,
+    private userService: UserService,
+    private snackBar: MatSnackBar,
     ) {
   }
 
@@ -36,4 +40,18 @@ export class GamesComponent implements OnInit {
         });
         this.gamesService.loadGamesList();
     }
+
+  canOpenGame(): boolean {
+    return this.userService.isUserLoaded();
+  }
+
+  onGameClick(event: MouseEvent) {
+    if (this.canOpenGame()) {
+      return;
+    }
+
+    event.preventDefault();
+    event.stopPropagation();
+    this.snackBar.open("Для просмотра деталей игры нужно авторизоваться", "OK", {duration: 3000});
+  }
 }

--- a/src/app/games/games.component.ts
+++ b/src/app/games/games.component.ts
@@ -46,10 +46,6 @@ export class GamesComponent implements OnInit {
   }
 
   onGameClick(event: MouseEvent) {
-    if (this.canOpenGame()) {
-      return;
-    }
-
     event.preventDefault();
     event.stopPropagation();
     this.snackBar.open("Для просмотра деталей игры нужно авторизоваться", "OK", {duration: 3000});

--- a/src/app/http/error.handler.ts
+++ b/src/app/http/error.handler.ts
@@ -7,6 +7,9 @@ import {AuthService} from "../auth/auth.service";
   providedIn: 'root'
 })
 export class GlobalErrorHandler implements ErrorHandler {
+  private readonly knownErrorTranslations: Record<string, string> = {
+    InvalidKey: "Неверный ключ",
+  };
   constructor(
     private _snackBar: MatSnackBar,
     private _zone: NgZone,
@@ -25,6 +28,17 @@ export class GlobalErrorHandler implements ErrorHandler {
         this.authService.showLoginForm();
       } else {
         console.error(error);
+        const backendError = error.error;
+        if (backendError && typeof backendError === "object") {
+          const type = String(backendError.type ?? "UnknownError");
+          const typeText = this.knownErrorTranslations[type] ?? type;
+          const text = String(backendError.text ?? "");
+          const description = String(backendError.description ?? "");
+          const message = [typeText, text, description].filter(v => v.length > 0).join(": ");
+          this._snackBar.open(message || "Ошибка запроса", 'Закрыть', {duration: 5000});
+          return;
+        }
+
         this._snackBar.open("Какая-то сетевая(?) ошибка=(", 'Закрыть', {duration: 3000});
       }
     });

--- a/src/app/http/http.adapter.ts
+++ b/src/app/http/http.adapter.ts
@@ -1,13 +1,19 @@
 import {Injectable} from "@angular/core";
 import {Observable} from "rxjs";
 import {ShvatkaConfig} from "../app.config";
-import {HttpClient} from "@angular/common/http";
+import {HttpClient, HttpErrorResponse} from "@angular/common/http";
+import {throwError} from "rxjs";
+import {AuthStateService} from "../auth/auth-state.service";
 
 @Injectable({
   providedIn: "root",
 })
 export class HttpAdapter {
-  constructor(private http: HttpClient, private config: ShvatkaConfig) {
+  constructor(
+    private http: HttpClient,
+    private config: ShvatkaConfig,
+    private authStateService: AuthStateService,
+  ) {
   }
 
   postWithoutCookies<T>(url: string, body: any): Observable<T> {
@@ -26,6 +32,9 @@ export class HttpAdapter {
   }
 
   get<T>(url: string): Observable<T> {
+    if (this.shouldBlockProtectedRequest(url)) {
+      return this.unauthorizedError(url);
+    }
     return this.http.get<T>(
       this.config.apiUrl + url,
       {withCredentials: true},
@@ -33,6 +42,9 @@ export class HttpAdapter {
   }
 
   put<T>(url: string, body: any): Observable<T> {
+    if (this.shouldBlockProtectedRequest(url)) {
+      return this.unauthorizedError(url);
+    }
     return this.http.put<T>(
       this.config.apiUrl + url,
       body,
@@ -45,5 +57,33 @@ export class HttpAdapter {
 
   getFileUrl(gameId: number, fileId: string): string {
     return `${this.config.apiUrl}/games/${gameId}/files/${fileId}`
+  }
+
+  private shouldBlockProtectedRequest(url: string): boolean {
+    if (!this.authStateService.isUnauthenticated()) {
+      return false;
+    }
+
+    return this.isProtectedUrl(url);
+  }
+
+  private isProtectedUrl(url: string): boolean {
+    return /^\/games\/\d+$/.test(url)
+      || /^\/games\/\d+\/keys$/.test(url)
+      || /^\/games\/\d+\/stat$/.test(url)
+      || /^\/games\/\d+\/files\/.+$/.test(url)
+      || url === "/games/active/me"
+      || url === "/games/running/level/current"
+      || url === "/games/running/key"
+      || url === "/users/me/password"
+      || url === "/teams/my";
+  }
+
+  private unauthorizedError<T>(url: string): Observable<T> {
+    return throwError(() => new HttpErrorResponse({
+      status: 401,
+      statusText: "Unauthorized",
+      url: this.config.apiUrl + url,
+    }));
   }
 }


### PR DESCRIPTION
### Motivation
- Improve UX for backend business errors by showing concise, user-friendly messages (`type`, `text`, `description`) while keeping full payloads in logs.
- Avoid issuing protected API requests once `/users/me` proved unauthenticated to reduce noisy failures and unnecessary network traffic.
- Ensure the app reloads and re-fetches data after a successful login so previously failed requests are retried and UI stays consistent.

### Description
- Added a centralized `AuthStateService` to track authenticated/unauthenticated/unknown state and drive client-side gating decisions (`src/app/auth/auth-state.service.ts`).
- Updated `UserService.loadMe()` to treat `401` and `404` as unauthenticated, call `showLoginForm()`, and update the `AuthStateService` on success/failure (`src/app/auth/user.service.ts`).
- Extended `HttpAdapter` to block protected endpoints client-side when the app knows the user is unauthenticated and return a synthetic `401` instead of performing the network call; protected routes are matched by the route patterns discussed (`src/app/http/http.adapter.ts`).
- Improved global error handling in `GlobalErrorHandler` to parse backend error JSON and display a composed message from `type`, `text`, and `description`, with a configurable translations map for known `type` values (unknown types are shown as-is) (`src/app/http/error.handler.ts`).
- Made the login flow reload the page after successful regular login so all previously loaded data is re-requested (`src/app/auth/auth.component.ts`).
- Prevent navigation into the game details list for unauthenticated users and show a snackbar hint instead (`src/app/games/games.component.ts` and template).

### Testing
- Ran the production build with `npm run -s build`, which completed successfully (build warnings for bundle/style size only) and the app bundle was generated without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03731f2820832a922b9be525b1297a)