### PR TITLE
Add collapsible effects spoiler for game events and extract effects helpers

### DIFF
--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -130,7 +130,31 @@
                 <strong>{{ toLocal(event.at) }}</strong>
                 @if(event.key) {<span>🔑{{event.key}}</span>}
                 @if(event.is_timer) {<span>🕑</span>}
-                <app-effects-part [effects]="event.effects" [gameId]="getCurrentHints()!.game_id"></app-effects-part>
+                @if (hasEventVisibleEffects(event)) {
+                  <button
+                    type="button"
+                    class="typed-key-toggle"
+                    (click)="toggleEventEffects(event)"
+                    [attr.aria-expanded]="isEventEffectsOpened(event)">
+                    <span class="typed-key-hint-pill" aria-hidden="true">✨ эффект</span>
+                  </button>
+                }
+                @if (isEventEffectsOpened(event)) {
+                  <div class="typed-effects">
+                    @for (tag of getEventEffects(event); track tag) {
+                      <span class="effect-tag">{{ tag }}</span>
+                    }
+                    @if (getEventHints(event).length > 0) {
+                      <ul class="typed-key-hints">
+                        @for (hint of getEventHints(event); track hint) {
+                          <li>
+                            <app-hint-part [hint]="hint" [fileUrl]="getFileUrl(hint)"></app-hint-part>
+                          </li>
+                        }
+                      </ul>
+                    }
+                  </div>
+                }
               </li>
             }
           </ul>
@@ -145,7 +169,31 @@
                   <strong>{{ toLocal(event.at) }}</strong>
                   @if(event.key) {<span>🔑{{event.key}}</span>}
                   @if(event.is_timer) {<span>🕑</span>}
-                  <app-effects-part [effects]="event.effects" [gameId]="getCurrentHints()!.game_id"></app-effects-part>
+                  @if (hasEventVisibleEffects(event)) {
+                    <button
+                      type="button"
+                      class="typed-key-toggle"
+                      (click)="toggleEventEffects(event)"
+                      [attr.aria-expanded]="isEventEffectsOpened(event)">
+                      <span class="typed-key-hint-pill" aria-hidden="true">✨ эффект</span>
+                    </button>
+                  }
+                  @if (isEventEffectsOpened(event)) {
+                    <div class="typed-effects">
+                      @for (tag of getEventEffects(event); track tag) {
+                        <span class="effect-tag">{{ tag }}</span>
+                      }
+                      @if (getEventHints(event).length > 0) {
+                        <ul class="typed-key-hints">
+                          @for (hint of getEventHints(event); track hint) {
+                            <li>
+                              <app-hint-part [hint]="hint" [fileUrl]="getFileUrl(hint)"></app-hint-part>
+                            </li>
+                          }
+                        </ul>
+                      }
+                    </div>
+                  }
                 </li>
               }
             </ul>

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -55,6 +55,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   private pageShowHandler: (() => void) | undefined;
   private windowFocusHandler: (() => void) | undefined;
   private openedTypedKeyEffects = new Set<string>();
+  private openedEventEffects = new Set<number>();
 
   constructor(
     private gameService: GamePlayService,
@@ -330,16 +331,11 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   }
 
   getTypedKeyEffects(typedKey: TypedKeyLog): string[] {
-    return Effects.normalize(typedKey?.effects)
-      .flatMap((effect: EffectLike) => this.getEffectTags(effect))
-      .filter((tag, idx, arr) => arr.indexOf(tag) === idx);
+    return this.getEffectsTags(typedKey?.effects);
   }
 
-
-
   getTypedKeyHints(typedKey: TypedKeyLog): HintPart[] {
-    return Effects.normalize(typedKey?.effects)
-      .flatMap((effect: EffectLike) => Effects.hints(effect));
+    return this.getEffectsHints(typedKey?.effects);
   }
 
   isTypedKeyTappable(typedKey: TypedKeyLog): boolean {
@@ -362,6 +358,35 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     }
 
     this.openedTypedKeyEffects.add(id);
+  }
+
+  hasEventVisibleEffects(event: GameEvent): boolean {
+    return Effects.normalize(event.effects).some(effect => Effects.hasVisiblePayload(effect));
+  }
+
+  getEventEffects(event: GameEvent): string[] {
+    return this.getEffectsTags(event.effects);
+  }
+
+  getEventHints(event: GameEvent): HintPart[] {
+    return this.getEffectsHints(event.effects);
+  }
+
+  isEventEffectsOpened(event: GameEvent): boolean {
+    return this.openedEventEffects.has(event.id);
+  }
+
+  toggleEventEffects(event: GameEvent): void {
+    if (!this.hasEventVisibleEffects(event)) {
+      return;
+    }
+
+    if (this.openedEventEffects.has(event.id)) {
+      this.openedEventEffects.delete(event.id);
+      return;
+    }
+
+    this.openedEventEffects.add(event.id);
   }
 
 
@@ -423,6 +448,17 @@ export class GamePlayComponent implements OnInit, OnDestroy {
       return '💤';
     }
     return '✅';
+  }
+
+  private getEffectsTags(effects: EffectLike[] | EffectLike | undefined): string[] {
+    return Effects.normalize(effects)
+      .flatMap((effect: EffectLike) => this.getEffectTags(effect))
+      .filter((tag, idx, arr) => arr.indexOf(tag) === idx);
+  }
+
+  private getEffectsHints(effects: EffectLike[] | EffectLike | undefined): HintPart[] {
+    return Effects.normalize(effects)
+      .flatMap((effect: EffectLike) => Effects.hints(effect));
   }
 
 


### PR DESCRIPTION
### Motivation
- Events previously always rendered effect details, but keys already had a spoiler toggle, so events should expose the same collapsible UX to avoid clutter and needless rendering. 
- Keep single-responsibility and remove duplication by centralizing effect tag/hint extraction into shared helpers. 

### Description
- Added per-event open state storage `openedEventEffects` and new methods `hasEventVisibleEffects`, `isEventEffectsOpened`, and `toggleEventEffects` in `src/app/game_play/game_play.component.ts` to manage event spoiler behavior. 
- Replaced always-visible `<app-effects-part>` for events in `src/app/game_play/game_play.component.html` with a compact `✨ эффект` toggle and conditional rendering of tags and hints for both current and previous level event lists. 
- Extracted duplicated logic into private helpers `getEffectsTags` and `getEffectsHints` and routed typed-key and event effect access through these helpers to follow SRP and reduce repetition. 

### Testing
- `npm run build` completed successfully (Angular build produced only existing bundle budget warnings). 
- `npm run lint` is not available in this repository because there is no `lint` script, so linting was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6a7f1320832a9e97f088829fc56b)