### PR TITLE
Add emojis to gameplay effect tags in spoilers

### DIFF
--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -310,21 +310,21 @@ export class GamePlayComponent implements OnInit, OnDestroy {
 
     const bonusMinutes = typeof effect.bonus_minutes === 'number' ? effect.bonus_minutes : 0;
     if (bonusMinutes > 0) {
-      tags.push(`бонус ${bonusMinutes} мин.`);
+      tags.push(`+💰бонус ${bonusMinutes} мин.`);
     } else if (bonusMinutes < 0) {
-      tags.push(`штраф ${-bonusMinutes} мин.`);
+      tags.push(`-💸штраф ${-bonusMinutes} мин.`);
     }
     if (effect.level_up) {
       if (effect.next_level) {
-        tags.push(`переход на ${effect.next_level}`);
+        tags.push(`🔀переход на ${effect.next_level}`);
       } else {
-        tags.push('переход на следующий уровень');
+        tags.push('✅переход на следующий уровень');
       }
     }
 
     const hintsCount = Effects.hints(effect).length;
     if (hintsCount > 0) {
-      tags.push(`бонусные подсказки: ${hintsCount}`);
+      tags.push(`💡бонусные подсказки: ${hintsCount}`);
     }
 
     return tags;


### PR DESCRIPTION
### Motivation
- Align in-play key/event effect labels with scenario presentation by adding visual emoji markers for level-ups, bonuses and hints.

### Description
- Modified `getEffectTags` in `src/app/game_play/game_play.component.ts` to prepend `+💰` for positive bonus minutes and `-💸` for penalties, to mark level-up transitions with `🔀` when a specific next level is provided and `✅` for a generic next-level transition, and to prefix bonus hints with `💡`.

### Testing
- Executed `npm run -s build` which completed successfully; the build output included pre-existing bundle/style budget warnings that are unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ffc95b758832aa5b91497dcc22a18)