### PR TITLE
Fix overflowing hint media layout

### DIFF
--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -6,10 +6,13 @@
 
 .app-shell {
   width: min(1100px, calc(100% - 2rem));
+  min-width: 0;
   margin: 1rem auto 2rem;
 }
 
 .app-content {
+  min-width: 0;
+  overflow-wrap: anywhere;
   background: color-mix(in srgb, var(--app-surface) 92%, transparent);
   color: var(--app-text);
   border-radius: 16px;

--- a/src/app/game_scenario.part/game_scenario.part.component.scss
+++ b/src/app/game_scenario.part/game_scenario.part.component.scss
@@ -1,9 +1,12 @@
 .scenario {
   display: grid;
+  grid-template-columns: minmax(0, 1fr);
   gap: 0.6rem;
+  min-width: 0;
 }
 
 .level-card {
+  min-width: 0;
   border: 1px solid #e5e7eb;
   border-radius: 10px;
   padding: 0.55rem 0.6rem;
@@ -73,6 +76,7 @@
 }
 
 .hint-item {
+  min-width: 0;
   list-style: none;
   border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 8px;

--- a/src/app/hint.part/hint.part.component.scss
+++ b/src/app/hint.part/hint.part.component.scss
@@ -1,7 +1,19 @@
-.hint-part img {
+.hint-part {
   max-width: 100%;
+  min-width: 0;
+  overflow-wrap: anywhere;
 }
 
+.hint-part img,
 .hint-part video {
+  display: block;
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+}
+
+.hint-part audio {
+  display: block;
+  width: 100%;
   max-width: 100%;
 }


### PR DESCRIPTION
### Motivation
- Hints containing images, videos or long text could force page horizontal overflow and break layout, so media must be constrained to card boundaries.
- The app shell and scenario grid needed shrinkable constraints so nested content can shrink instead of increasing viewport width.

### Description
- Constrain root/app containers by adding `min-width: 0` and `overflow-wrap: anywhere` to `src/app/app.component.scss` so content can shrink without creating horizontal scroll.
- Make the scenario grid and cards shrinkable by adding `grid-template-columns: minmax(0, 1fr)` and `min-width: 0` to `src/app/game_scenario.part/game_scenario.part.component.scss` and to `.hint-item` so hint cards stay within borders.
- Ensure hint media and audio render as block-level and scale to card width by updating `src/app/hint.part/hint.part.component.scss` to set `.hint-part` wrapping rules and `img`, `video`, `audio` to `display: block; width: 100%; max-width: 100%; height: auto;`.

### Testing
- Ran `npm run build` and the Angular build completed successfully (bundle/style budget warnings reported but build succeeded). 
- Ran unit test command `npm test -- --watch=false --browsers=ChromeHeadless` which failed to launch because the `ChromeHeadless` binary is not available in this environment (`CHROME_BIN` unset). 
- Ran `git diff --check` to validate there are no whitespace/errors in diffs and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c55fedbc0832aba88b0ecfacbe7ee)