### PR TITLE
Render hint text and caption as HTML

### DIFF
--- a/src/app/hint.part/hint.part.component.html
+++ b/src/app/hint.part/hint.part.component.html
@@ -1,7 +1,7 @@
 <div class="hint-part">
   @switch (hint.type) {
     @case (HintType.text) {
-      <p class="hint-text">{{ hint.text }}</p>
+      <p class="hint-text" [innerHTML]="hint.text"></p>
     }
     @case (HintType.gps) {
       <a [href]="'https://maps.yandex.ru/?ll=' + hint.longitude + ',' + hint.latitude + '&z=18'">
@@ -57,6 +57,6 @@
     }
   }
   @if (hint.caption) {
-    <p>{{ hint.caption }}</p>
+    <p [innerHTML]="hint.caption"></p>
   }
 </div>


### PR DESCRIPTION
### Motivation
- Some hint texts and captions include HTML markup (for example `<blockquote><code>...</code></blockquote>`) and should be rendered as formatted HTML in the UI instead of being displayed as escaped raw text.

### Description
- Update `src/app/hint.part/hint.part.component.html` to use `[innerHTML]` for `hint.text` and `hint.caption`, replacing `{{ hint.text }}` with `<p class="hint-text" [innerHTML]="hint.text"></p>` and `{{ hint.caption }}` with `<p [innerHTML]="hint.caption"></p>` so embedded HTML is processed.

### Testing
- Executed `npm test -- --watch=false --browsers=ChromeHeadless --include src/app/hint.part/hint.part.component.spec.ts`, which could not run to completion in this environment because the `ChromeHeadless` binary / `CHROME_BIN` is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12d80f5d34832aa45544f55a6652a6)