### PR TITLE
#60 browser push notifications for the PWA

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -27,7 +27,12 @@
             "inlineStyleLanguage": "scss",
             "assets": [
               "src/favicon.ico",
-              "src/assets"
+              "src/assets",
+              {
+                "glob": "push-sw.js",
+                "input": "src",
+                "output": "/"
+              }
             ],
             "styles": [
               "@angular/material/prebuilt-themes/indigo-pink.css",

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -8,6 +8,7 @@ import {DomSanitizer} from "@angular/platform-browser";
 import {ThemeService} from "./theme/theme.service";
 import {filter} from "rxjs";
 import {VersionInfo, VersionService} from "./version/version.service";
+import {PushService} from "./push/push.service";
 
 @Component({
   selector: 'app-root',
@@ -34,6 +35,7 @@ export class AppComponent implements OnInit {
     private themeService: ThemeService,
     private versionService: VersionService,
     private router: Router,
+    private pushService: PushService,
     @Inject(DOCUMENT) private document: Document,
   ) {
     this.matIconRegistry.addSvgIcon(
@@ -51,6 +53,10 @@ export class AppComponent implements OnInit {
     this.versionService.getFrontendVersion().subscribe(version => this.frontendVersion = version);
     this.versionService.getBackendVersion().subscribe(version => this.backendVersion = version);
     this.debugInfo = this.window?.sessionStorage.getItem("debug-log") ?? "";
+
+    // Registers the push service worker and, if permission is already granted,
+    // refreshes the saved subscription. Never prompts for permission on load.
+    this.pushService.init();
   }
 
   toggleDebugInfo() {

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -1,3 +1,7 @@
+<div class="push-toggle-bar">
+  <app-push-toggle></app-push-toggle>
+</div>
+
 @if (isLoading()) {
   <p class="status-message">Загрузка текущей игры...</p>
 }

--- a/src/app/game_play/game_play.component.scss
+++ b/src/app/game_play/game_play.component.scss
@@ -2,6 +2,12 @@
   text-align: center;
 }
 
+.push-toggle-bar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.75rem;
+}
+
 .status-message {
   color: var(--tg-theme-hint-color, #6b7280);
 }

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -21,6 +21,7 @@ import {GameLogPartComponent} from "../game_log.part/game_log.part.component";
 import {EffectsPartComponent} from "../effects.part/effects.part.component";
 import {UserService} from "../auth/user.service";
 import {GameScenarioPartComponent} from "../game_scenario.part/game_scenario.part.component";
+import {PushToggleComponent} from "../push/push-toggle.component";
 
 @Component({
   selector: 'app-game-play',
@@ -31,6 +32,7 @@ import {GameScenarioPartComponent} from "../game_scenario.part/game_scenario.par
     GameLogPartComponent,
     EffectsPartComponent,
     GameScenarioPartComponent,
+    PushToggleComponent,
   ],
   templateUrl: './game_play.component.html',
   styleUrl: './game_play.component.scss'

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -8,6 +8,7 @@ import {Router, RouterLink, RouterLinkActive} from "@angular/router";
 import {MatIcon} from "@angular/material/icon";
 import {ActiveGame, GamesService} from "../games/games.service";
 import {THEME_MODES, ThemeMode, ThemeService} from "../theme/theme.service";
+import {PushService} from "../push/push.service";
 
 type CountdownUnit = "days" | "hours" | "minutes" | "seconds";
 
@@ -49,6 +50,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private gamesService: GamesService,
     private router: Router,
     private themeService: ThemeService,
+    private pushService: PushService,
   ) {
     this.window = this._document.defaultView;
     this.tg = (this.window as any)?.Telegram;
@@ -61,7 +63,9 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   logout() {
-    this.authService.logout().subscribe(() => this.userService.clearUser());
+    this.pushService.onLogout().finally(() => {
+      this.authService.logout().subscribe(() => this.userService.clearUser());
+    });
     this.closeMobileMenu();
   }
 
@@ -123,6 +127,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
       const telegramAuthResult = await this.authenticateTelegramWebApp(this.tgWa);
       if (telegramAuthResult) {
         await this.userService.loadMe();
+        this.pushService.refresh();
         this.tgWa?.ready?.();
         return;
       }

--- a/src/app/http/http.adapter.ts
+++ b/src/app/http/http.adapter.ts
@@ -55,6 +55,20 @@ export class HttpAdapter {
     );
   }
 
+  delete<T>(url: string, body?: any): Observable<T> {
+    if (this.shouldBlockProtectedRequest(url)) {
+      return this.unauthorizedError(url);
+    }
+    return this.http.delete<T>(
+      this.config.apiUrl + url,
+      {
+        withCredentials: true,
+        headers: {"Content-Type": "application/json"},
+        body,
+      },
+    );
+  }
+
   getFileUrl(gameId: number, fileId: string): string {
     return `${this.config.cdnUrl}/games/${gameId}/files/${fileId}`
   }

--- a/src/app/profile/profile.component.html
+++ b/src/app/profile/profile.component.html
@@ -4,6 +4,11 @@
   @if (isAuthenticated) {
     <p class="username">Пользователь: <strong>{{ username }}</strong></p>
 
+    <div class="notifications-block">
+      <h2 class="notifications-title">Уведомления</h2>
+      <app-push-toggle></app-push-toggle>
+    </div>
+
     <form class="password-form" (ngSubmit)="changePassword()">
       <label for="newPassword">Новый пароль</label>
       <input

--- a/src/app/profile/profile.component.scss
+++ b/src/app/profile/profile.component.scss
@@ -16,6 +16,18 @@ h1 {
   color: inherit;
 }
 
+.notifications-block {
+  margin-bottom: 1.25rem;
+  padding-bottom: 1.25rem;
+  border-bottom: 1px solid var(--app-border);
+}
+
+.notifications-title {
+  margin: 0 0 0.6rem;
+  font-size: 1.05rem;
+  color: inherit;
+}
+
 .password-form {
   display: flex;
   flex-direction: column;

--- a/src/app/profile/profile.component.ts
+++ b/src/app/profile/profile.component.ts
@@ -4,11 +4,12 @@ import {NgIf} from '@angular/common';
 import {HttpErrorResponse} from '@angular/common/http';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {UserService} from '../auth/user.service';
+import {PushToggleComponent} from '../push/push-toggle.component';
 
 @Component({
   selector: 'app-profile',
   standalone: true,
-  imports: [FormsModule, NgIf],
+  imports: [FormsModule, NgIf, PushToggleComponent],
   templateUrl: './profile.component.html',
   styleUrl: './profile.component.scss',
 })

--- a/src/app/push/push-toggle.component.html
+++ b/src/app/push/push-toggle.component.html
@@ -1,0 +1,47 @@
+@switch (push.state()) {
+  @case ('unsupported') {
+    <span class="push-note push-note-muted">
+      Уведомления не поддерживаются этим браузером
+    </span>
+  }
+  @case ('disabled') {
+    <span class="push-note push-note-muted">
+      Push-уведомления отключены на сервере
+    </span>
+  }
+  @case ('denied') {
+    <span class="push-note push-note-warn">
+      Уведомления заблокированы. Разрешите их в настройках браузера
+    </span>
+  }
+  @case ('granted') {
+    <button
+      type="button"
+      class="push-button push-button-on"
+      [disabled]="push.busy()"
+      (click)="disable()"
+    >
+      <svg class="push-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="currentColor"
+              d="M12 22a2.5 2.5 0 0 0 2.45-2h-4.9A2.5 2.5 0 0 0 12 22m8-5v-1l-1.5-1.5V10a6.5 6.5 0 0 0-5-6.32V3a1.5 1.5 0 0 0-3 0v.68A6.5 6.5 0 0 0 5.5 10v4.5L4 16v1z"/>
+        <path fill="currentColor"
+              d="m20.7 19.3-16-16-1.4 1.4 16 16z" opacity="0.9"/>
+      </svg>
+      {{ push.busy() ? 'Отключаем…' : 'Отключить уведомления' }}
+    </button>
+  }
+  @default {
+    <button
+      type="button"
+      class="push-button"
+      [disabled]="push.busy()"
+      (click)="enable()"
+    >
+      <svg class="push-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="currentColor"
+              d="M12 22a2.5 2.5 0 0 0 2.45-2h-4.9A2.5 2.5 0 0 0 12 22m6.5-6V10a6.5 6.5 0 0 0-5-6.32V3a1.5 1.5 0 0 0-3 0v.68A6.5 6.5 0 0 0 5.5 10v6l-1.5 1.5V18h16v-.5z"/>
+      </svg>
+      {{ push.busy() ? 'Включаем…' : 'Включить уведомления' }}
+    </button>
+  }
+}

--- a/src/app/push/push-toggle.component.scss
+++ b/src/app/push/push-toggle.component.scss
@@ -1,0 +1,45 @@
+@use '../../styles/component-mixins' as cm;
+
+:host {
+  display: inline-flex;
+  align-items: center;
+}
+
+.push-button {
+  @include cm.button-base();
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: var(--app-accent);
+  color: var(--app-accent-contrast);
+}
+
+.push-button:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.push-button-on {
+  background: transparent;
+  color: var(--app-text);
+  border: 1px solid var(--app-border);
+}
+
+.push-icon {
+  width: 18px;
+  height: 18px;
+}
+
+.push-note {
+  font-size: 0.85rem;
+  line-height: 1.3;
+}
+
+.push-note-muted {
+  color: var(--app-text);
+  opacity: 0.7;
+}
+
+.push-note-warn {
+  color: #c0392b;
+}

--- a/src/app/push/push-toggle.component.ts
+++ b/src/app/push/push-toggle.component.ts
@@ -1,0 +1,22 @@
+import {Component} from '@angular/core';
+import {PushService} from './push.service';
+
+@Component({
+  selector: 'app-push-toggle',
+  standalone: true,
+  imports: [],
+  templateUrl: './push-toggle.component.html',
+  styleUrl: './push-toggle.component.scss',
+})
+export class PushToggleComponent {
+  constructor(public push: PushService) {
+  }
+
+  enable(): void {
+    this.push.enable();
+  }
+
+  disable(): void {
+    this.push.disable();
+  }
+}

--- a/src/app/push/push.service.ts
+++ b/src/app/push/push.service.ts
@@ -1,0 +1,304 @@
+import {Injectable, NgZone, signal} from '@angular/core';
+import {Router} from '@angular/router';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {firstValueFrom} from 'rxjs';
+import {HttpAdapter} from '../http/http.adapter';
+
+export interface PushConfig {
+  enabled: boolean;
+  public_key: string | null;
+}
+
+export interface BackendPushPayload {
+  title: string;
+  body: string;
+  url?: string;
+  tag?: string;
+  data?: Record<string, unknown>;
+}
+
+/**
+ * UI-facing state of push notifications:
+ *  - unsupported: browser lacks the required APIs
+ *  - disabled:    backend reports push is turned off (or has no public key)
+ *  - default:     supported, permission not yet requested
+ *  - denied:      user blocked notifications in the browser
+ *  - granted:     permission granted and a subscription is registered
+ */
+export type PushState = 'unsupported' | 'disabled' | 'default' | 'denied' | 'granted';
+
+const SW_URL = '/push-sw.js';
+
+@Injectable({providedIn: 'root'})
+export class PushService {
+  readonly state = signal<PushState>('default');
+  readonly busy = signal(false);
+
+  private config: PushConfig | undefined;
+  private registration: ServiceWorkerRegistration | undefined;
+  private messageHandlerBound = false;
+
+  constructor(
+    private http: HttpAdapter,
+    private router: Router,
+    private snackBar: MatSnackBar,
+    private zone: NgZone,
+  ) {
+  }
+
+  isSupported(): boolean {
+    return typeof navigator !== 'undefined'
+      && 'serviceWorker' in navigator
+      && typeof window !== 'undefined'
+      && 'PushManager' in window
+      && 'Notification' in window;
+  }
+
+  /**
+   * Called once on app bootstrap. Registers the service worker, listens for
+   * foreground messages and, when permission was already granted, refreshes the
+   * saved subscription so the backend always knows the current endpoint.
+   */
+  async init(): Promise<void> {
+    if (!this.isSupported()) {
+      this.state.set('unsupported');
+      return;
+    }
+
+    this.bindMessageHandler();
+
+    try {
+      this.registration = await this.registerServiceWorker();
+    } catch (e) {
+      console.error('push: service worker registration failed', e);
+      return;
+    }
+
+    if (Notification.permission === 'granted') {
+      await this.refresh();
+    } else {
+      await this.syncState();
+    }
+  }
+
+  /** User action: enable notifications from a visible button. */
+  async enable(): Promise<void> {
+    if (!this.isSupported()) {
+      this.state.set('unsupported');
+      this.notify('Этот браузер не поддерживает уведомления');
+      return;
+    }
+    if (this.busy()) {
+      return;
+    }
+
+    this.busy.set(true);
+    try {
+      const config = await this.loadConfig();
+      if (!config.enabled || !config.public_key) {
+        this.state.set('disabled');
+        this.notify('Push-уведомления сейчас отключены на сервере');
+        return;
+      }
+
+      this.registration = await this.registerServiceWorker();
+
+      const permission = await Notification.requestPermission();
+      if (permission !== 'granted') {
+        this.state.set(permission === 'denied' ? 'denied' : 'default');
+        this.notify(
+          permission === 'denied'
+            ? 'Уведомления заблокированы в настройках браузера'
+            : 'Разрешение на уведомления не получено',
+        );
+        return;
+      }
+
+      const subscription = await this.subscribe(config.public_key);
+      await this.sendSubscription(subscription);
+      this.state.set('granted');
+      this.notify('Уведомления включены');
+    } catch (e) {
+      console.error('push: enable failed', e);
+      this.notify('Не удалось включить уведомления');
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  /** User action: disable notifications from a visible button. */
+  async disable(): Promise<void> {
+    if (!this.isSupported() || this.busy()) {
+      return;
+    }
+
+    this.busy.set(true);
+    try {
+      await this.removeSubscription();
+      await this.syncState();
+      this.notify('Уведомления отключены');
+    } catch (e) {
+      console.error('push: disable failed', e);
+      this.notify('Не удалось отключить уведомления');
+    } finally {
+      this.busy.set(false);
+    }
+  }
+
+  /** Called on logout: drop the subscription so the backend stops sending. */
+  async onLogout(): Promise<void> {
+    if (!this.isSupported()) {
+      return;
+    }
+    try {
+      await this.removeSubscription();
+    } catch (e) {
+      console.error('push: logout cleanup failed', e);
+    }
+  }
+
+  /**
+   * Re-registers the current browser subscription with the backend. Safe to call
+   * repeatedly: pushManager.subscribe returns the existing subscription for the
+   * same endpoint, so refresh/re-login never creates duplicates.
+   */
+  async refresh(): Promise<void> {
+    if (!this.isSupported() || Notification.permission !== 'granted') {
+      return;
+    }
+
+    try {
+      const config = await this.loadConfig();
+      if (!config.enabled) {
+        this.state.set('disabled');
+        return;
+      }
+
+      const registration = await this.ensureRegistration();
+      const subscription = await registration.pushManager.getSubscription();
+      if (subscription) {
+        await this.sendSubscription(subscription);
+        this.state.set('granted');
+      } else {
+        this.state.set('default');
+      }
+    } catch (e) {
+      console.error('push: refresh failed', e);
+    }
+  }
+
+  private async subscribe(publicKey: string): Promise<PushSubscription> {
+    const registration = await this.ensureRegistration();
+    const existing = await registration.pushManager.getSubscription();
+    if (existing) {
+      return existing;
+    }
+    return registration.pushManager.subscribe({
+      userVisibleOnly: true,
+      applicationServerKey: urlBase64ToUint8Array(publicKey),
+    });
+  }
+
+  private async removeSubscription(): Promise<void> {
+    const registration = await this.ensureRegistration();
+    const subscription = await registration.pushManager.getSubscription();
+    if (!subscription) {
+      return;
+    }
+
+    try {
+      await firstValueFrom(this.http.delete('/push/subscriptions', subscription.toJSON()));
+    } catch (e) {
+      // Even if the backend call fails we still unsubscribe locally.
+      console.error('push: DELETE /push/subscriptions failed', e);
+    }
+    await subscription.unsubscribe();
+  }
+
+  private async sendSubscription(subscription: PushSubscription): Promise<void> {
+    await firstValueFrom(this.http.put('/push/subscriptions', subscription.toJSON()));
+  }
+
+  private async loadConfig(): Promise<PushConfig> {
+    this.config = await firstValueFrom(this.http.get<PushConfig>('/push/config'));
+    return this.config;
+  }
+
+  private async ensureRegistration(): Promise<ServiceWorkerRegistration> {
+    if (!this.registration) {
+      this.registration = await this.registerServiceWorker();
+    }
+    return this.registration;
+  }
+
+  private registerServiceWorker(): Promise<ServiceWorkerRegistration> {
+    return navigator.serviceWorker.register(SW_URL);
+  }
+
+  /**
+   * Derives the UI state from the real world: 'granted' only when an active
+   * subscription exists, so disabling/unsubscribing correctly falls back to the
+   * "enable" state even though the browser permission stays granted.
+   */
+  private async syncState(): Promise<void> {
+    if (!this.isSupported()) {
+      this.state.set('unsupported');
+      return;
+    }
+    if (Notification.permission === 'denied') {
+      this.state.set('denied');
+      return;
+    }
+    try {
+      const registration = await this.ensureRegistration();
+      const subscription = await registration.pushManager.getSubscription();
+      this.state.set(subscription ? 'granted' : 'default');
+    } catch (e) {
+      console.error('push: state sync failed', e);
+      this.state.set('default');
+    }
+  }
+
+  private bindMessageHandler(): void {
+    if (this.messageHandlerBound) {
+      return;
+    }
+    this.messageHandlerBound = true;
+
+    navigator.serviceWorker.addEventListener('message', (event: MessageEvent) => {
+      const data = event.data || {};
+      this.zone.run(() => {
+        if (data.type === 'push' && data.payload) {
+          this.showForegroundToast(data.payload as BackendPushPayload);
+        } else if (data.type === 'notificationclick' && data.url) {
+          this.router.navigateByUrl(data.url);
+        }
+      });
+    });
+  }
+
+  private showForegroundToast(payload: BackendPushPayload): void {
+    const message = payload.body ? `${payload.title}: ${payload.body}` : payload.title;
+    const url = payload.url || (payload.data?.['url'] as string | undefined);
+    const ref = this.snackBar.open(message, url ? 'Открыть' : 'OK', {duration: 6000});
+    if (url) {
+      ref.onAction().subscribe(() => this.router.navigateByUrl(url));
+    }
+  }
+
+  private notify(message: string): void {
+    this.snackBar.open(message, 'OK', {duration: 4000});
+  }
+}
+
+/** Converts a base64url VAPID public key into the Uint8Array the Push API needs. */
+function urlBase64ToUint8Array(base64String: string): Uint8Array {
+  const padding = '='.repeat((4 - (base64String.length % 4)) % 4);
+  const base64 = (base64String + padding).replace(/-/g, '+').replace(/_/g, '/');
+  const raw = atob(base64);
+  const output = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) {
+    output[i] = raw.charCodeAt(i);
+  }
+  return output;
+}

--- a/src/push-sw.js
+++ b/src/push-sw.js
@@ -1,0 +1,86 @@
+/*
+ * Shvatka push service worker.
+ *
+ * Handles the native Web Push protocol for the backend whose payloads are flat
+ * objects: { title, body, url?, tag?, data? }. It is intentionally tiny and has
+ * no dependency on @angular/service-worker, so the regular Angular build is
+ * untouched. The file is copied to the site root (/push-sw.js) by angular.json,
+ * which gives it the "/" scope required to control the whole app.
+ */
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+function parsePayload(event) {
+  if (!event.data) {
+    return { title: 'Shvatka', body: '' };
+  }
+  try {
+    return event.data.json();
+  } catch (e) {
+    return { title: 'Shvatka', body: event.data.text() };
+  }
+}
+
+function resolveUrl(payload) {
+  return payload.url || (payload.data && payload.data.url) || '/';
+}
+
+self.addEventListener('push', (event) => {
+  const payload = parsePayload(event) || {};
+  const title = payload.title || 'Shvatka';
+  const url = resolveUrl(payload);
+
+  const options = {
+    body: payload.body || '',
+    icon: '/assets/icons/web-app-manifest-192x192.png',
+    badge: '/assets/icons/favicon-96x96.png',
+    data: Object.assign({}, payload.data, { url }),
+  };
+  if (payload.tag) {
+    options.tag = payload.tag;
+    options.renotify = true;
+  }
+
+  const showNotification = self.registration.showNotification(title, options);
+
+  // Let any open tab show an in-app toast for foreground messages.
+  const notifyClients = self.clients
+    .matchAll({ type: 'window', includeUncontrolled: true })
+    .then((clients) => {
+      clients.forEach((client) => client.postMessage({ type: 'push', payload }));
+    });
+
+  event.waitUntil(Promise.all([showNotification, notifyClients]));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const data = event.notification.data || {};
+  const url = data.url || '/';
+
+  event.waitUntil(
+    (async () => {
+      const clients = await self.clients.matchAll({
+        type: 'window',
+        includeUncontrolled: true,
+      });
+      for (const client of clients) {
+        if ('focus' in client) {
+          await client.focus();
+          // Ask the running SPA to route in place instead of reloading.
+          client.postMessage({ type: 'notificationclick', url });
+          return;
+        }
+      }
+      if (self.clients.openWindow) {
+        await self.clients.openWindow(url);
+      }
+    })(),
+  );
+});


### PR DESCRIPTION
Implements browser push notifications for the PWA using the native Web Push API + a hand-written service worker (no new npm deps).

- PushService: GET /push/config, PUT/DELETE /push/subscriptions, PushManager subscribe/refresh/remove.
- push-sw.js: renders backend flat payload, click navigation, foreground postMessage.
- Reusable app-push-toggle button (bell icon) in profile + top of /games/running, with unsupported/disabled/denied/default/granted states.
- Refresh on bootstrap/login if granted; cleanup on logout/disable.

Closes #60

⚠️ Build/e2e not run in the CI sandbox (network/exec blocked) — please run `npm ci && npm run build` and device smoke tests.

Generated with [Claude Code](https://claude.ai/code)