### PR TITLE
Customize snackbar: distinct styles for success, error, info

### DIFF
--- a/src/app/auth/auth.component.ts
+++ b/src/app/auth/auth.component.ts
@@ -1,6 +1,6 @@
 import {AfterViewInit, Component, ElementRef, OnInit, ViewChild} from '@angular/core';
-import {MatSnackBar} from "@angular/material/snack-bar";
 import {AuthService} from "./auth.service";
+import {SnackbarService} from "../snackbar/snackbar.service";
 import {FormsModule} from "@angular/forms";
 import {NgClass, NgIf, NgStyle} from "@angular/common";
 import {UserService} from "./user.service";
@@ -29,7 +29,7 @@ export class AuthComponent implements AfterViewInit, OnInit {
     public authService: AuthService,
     private userService: UserService,
     private config: ShvatkaConfig,
-    private snackBar: MatSnackBar,
+    private snackbar: SnackbarService,
   ) {
     authService.registerCallback(this);
   }
@@ -47,7 +47,7 @@ export class AuthComponent implements AfterViewInit, OnInit {
             if (err instanceof HttpErrorResponse && err.status === 401) {
               console.error("auth error " + err.message);
               console.log(JSON.stringify(err));
-              this.snackBar.open('Неверные имя пользователя или пароль', "ok");
+              this.snackbar.error('Неверные имя пользователя или пароль');
             } else {
               throw err;
             }

--- a/src/app/auth/one-time-token.component.ts
+++ b/src/app/auth/one-time-token.component.ts
@@ -2,8 +2,8 @@ import {Component, OnInit} from '@angular/core';
 import {firstValueFrom} from 'rxjs';
 import {AuthService} from './auth.service';
 import {UserService} from './user.service';
-import {MatSnackBar} from '@angular/material/snack-bar';
 import {ActivatedRoute, Router} from '@angular/router';
+import {SnackbarService} from '../snackbar/snackbar.service';
 import {HttpErrorResponse} from '@angular/common/http';
 
 @Component({
@@ -18,7 +18,7 @@ export class OneTimeTokenComponent implements OnInit {
     private userService: UserService,
     private route: ActivatedRoute,
     private router: Router,
-    private snackBar: MatSnackBar,
+    private snackbar: SnackbarService,
   ) {
   }
 
@@ -27,7 +27,7 @@ export class OneTimeTokenComponent implements OnInit {
     const next = this.route.snapshot.queryParamMap.get('next') || '/';
 
     if (!token) {
-      this.snackBar.open('Missing one-time token', 'ok');
+      this.snackbar.error('Missing one-time token');
       await this.router.navigateByUrl('/');
       return;
     }
@@ -38,9 +38,9 @@ export class OneTimeTokenComponent implements OnInit {
       await this.router.navigateByUrl(next);
     } catch (err) {
       if (err instanceof HttpErrorResponse && err.status === 401) {
-        this.snackBar.open('Invalid or expired one-time token', 'ok');
+        this.snackbar.error('Invalid or expired one-time token');
       } else {
-        this.snackBar.open('Authentication failed', 'ok');
+        this.snackbar.error('Authentication failed');
       }
       await this.router.navigateByUrl('/');
     }

--- a/src/app/game/game.service.ts
+++ b/src/app/game/game.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpAdapter} from "../http/http.adapter";
 import {HttpErrorResponse} from "@angular/common/http";
-import {MatSnackBar} from "@angular/material/snack-bar";
+import {SnackbarService} from "../snackbar/snackbar.service";
 
 import {FullGame, GameStat, Keys} from "../domain/game.models";
 type GameCacheItem = {
@@ -25,7 +25,7 @@ export class GameService {
   private isKeysLoading = false;
   private isStatLoading = false;
 
-  constructor(private http: HttpAdapter, private snackBar: MatSnackBar) { }
+  constructor(private http: HttpAdapter, private snackbar: SnackbarService) { }
 
   loadGame(id: number) {
     this.currentGameId = id;
@@ -63,7 +63,7 @@ export class GameService {
           }
 
           if (error instanceof HttpErrorResponse && error.status === 401) {
-            this.snackBar.open("Сценарии игр доступны только авторизованным пользователям", 'Закрыть', {duration: 3000});
+            this.snackbar.error("Сценарии игр доступны только авторизованным пользователям", 'Закрыть', 3000);
           } else {
             throw error;
           }

--- a/src/app/game_play/game_play.service.ts
+++ b/src/app/game_play/game_play.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpAdapter} from "../http/http.adapter";
 import {HttpErrorResponse} from "@angular/common/http";
-import {MatSnackBar} from "@angular/material/snack-bar";
+import {SnackbarService} from "../snackbar/snackbar.service";
 import {Effect, Effects, GameStat, KeyTime, Keys, TimeHint} from "../domain/game.models";
 import {Observable, tap} from "rxjs";
 import {ActiveGame, GamesService} from "../games/games.service";
@@ -145,7 +145,7 @@ export class GamePlayService {
 
   constructor(
     private http: HttpAdapter,
-    private snackBar: MatSnackBar,
+    private snackbar: SnackbarService,
     private gamesService: GamesService,
   ) {
   }
@@ -204,7 +204,7 @@ export class GamePlayService {
         if (error instanceof HttpErrorResponse && error.status === 401) {
           this.authRequired = true;
           console.log("current hint 401 response: " + JSON.stringify(error));
-          this.snackBar.open("Играть можно только авторизованным пользователям в составе команд", 'Закрыть', {duration: 3000});
+          this.snackbar.error("Играть можно только авторизованным пользователям в составе команд", 'Закрыть', 3000);
         } else {
           throw error;
         }
@@ -226,7 +226,7 @@ export class GamePlayService {
 
           if (error instanceof HttpErrorResponse && error.status === 401) {
             this.authRequired = true;
-            this.snackBar.open("Просмотр вейверов доступен только авторизованным пользователям", 'Закрыть', {duration: 3000});
+            this.snackbar.error("Просмотр вейверов доступен только авторизованным пользователям", 'Закрыть', 3000);
           } else {
             throw error;
           }
@@ -420,7 +420,7 @@ export class GamePlayService {
     return this.http.post<TypedKeyResult>(`/games/running/key`, {text}).pipe(
       tap(result => {
         if (Effects.normalize(result.effects).some(effect => effect.level_up)) {
-          this.snackBar.open("Уровень пройден! Загружаем следующий уровень.", 'Закрыть', {duration: 3000});
+          this.snackbar.success("Уровень пройден! Загружаем следующий уровень.", 'Закрыть', 3000);
           this.loadHints();
         }
       }),

--- a/src/app/games/games.component.ts
+++ b/src/app/games/games.component.ts
@@ -2,7 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {Game, GamesService} from "./games.service";
 import {ActivatedRoute, Params, Router, RouterLink, RouterLinkActive} from "@angular/router";
 import {UserService} from "../auth/user.service";
-import {MatSnackBar} from "@angular/material/snack-bar";
+import {SnackbarService} from "../snackbar/snackbar.service";
 
 
 @Component({
@@ -21,7 +21,7 @@ export class GamesComponent implements OnInit {
     private activatedRoute: ActivatedRoute,
     private router: Router,
     private userService: UserService,
-    private snackBar: MatSnackBar,
+    private snackbar: SnackbarService,
     ) {
   }
 
@@ -48,6 +48,6 @@ export class GamesComponent implements OnInit {
   onGameClick(event: MouseEvent) {
     event.preventDefault();
     event.stopPropagation();
-    this.snackBar.open("Для просмотра деталей игры нужно авторизоваться", "OK", {duration: 3000});
+    this.snackbar.info("Для просмотра деталей игры нужно авторизоваться");
   }
 }

--- a/src/app/http/error.handler.ts
+++ b/src/app/http/error.handler.ts
@@ -19,7 +19,10 @@ export class GlobalErrorHandler implements ErrorHandler {
   handleError(error: any): void {
     this._zone.run(() => {
       if (!(error instanceof HttpErrorResponse)) {
-        console.error(error)
+        console.error(error);
+        const name = error?.name || error?.constructor?.name || 'Error';
+        const text = error?.message || String(error);
+        this.snackbar.error(`${name}: ${text}`, 'Закрыть');
         return
       }
       if (error.status === 401) {
@@ -34,12 +37,16 @@ export class GlobalErrorHandler implements ErrorHandler {
           const typeText = this.knownErrorTranslations[type] ?? type;
           const text = String(backendError.text ?? "");
           const description = String(backendError.description ?? "");
-          const message = [typeText, text, description].filter(v => v.length > 0).join(": ");
-          this.snackbar.error(message || "Ошибка запроса", 'Закрыть');
+          const parts = [typeText, text, description].filter(v => v.length > 0).join(": ");
+          const message = `[${error.status}] ${parts || "Ошибка запроса"}`;
+          this.snackbar.error(message, 'Закрыть');
           return;
         }
 
-        this.snackbar.error("Какая-то сетевая(?) ошибка=(", 'Закрыть', 3000);
+        this.snackbar.error(
+          `[${error.status}] ${error.statusText || 'Ошибка сети'}`,
+          'Закрыть',
+        );
       }
     });
   }

--- a/src/app/http/error.handler.ts
+++ b/src/app/http/error.handler.ts
@@ -44,10 +44,27 @@ export class GlobalErrorHandler implements ErrorHandler {
         }
 
         this.snackbar.error(
-          `[${error.status}] ${error.statusText || 'Ошибка сети'}`,
+          this.formatUnknownHttpError(error),
           'Закрыть',
         );
       }
     });
+  }
+
+  private formatUnknownHttpError(error: HttpErrorResponse): string {
+    if (error.status === 0) {
+      return `Ошибка сети: сервер недоступен (${this.extractPath(error.url)})`;
+    }
+    const statusText = error.statusText || 'Unknown Error';
+    return `[${error.status}] ${statusText} (${this.extractPath(error.url)})`;
+  }
+
+  private extractPath(url: string | null): string {
+    if (!url) return '';
+    try {
+      return new URL(url).pathname;
+    } catch {
+      return url;
+    }
   }
 }

--- a/src/app/http/error.handler.ts
+++ b/src/app/http/error.handler.ts
@@ -1,7 +1,7 @@
 import {ErrorHandler, Injectable, NgZone} from "@angular/core";
-import {MatSnackBar} from "@angular/material/snack-bar";
 import {HttpErrorResponse} from "@angular/common/http";
 import {AuthService} from "../auth/auth.service";
+import {SnackbarService} from "../snackbar/snackbar.service";
 
 @Injectable({
   providedIn: 'root'
@@ -11,7 +11,7 @@ export class GlobalErrorHandler implements ErrorHandler {
     InvalidKey: "Неверный ключ",
   };
   constructor(
-    private _snackBar: MatSnackBar,
+    private snackbar: SnackbarService,
     private _zone: NgZone,
     private authService: AuthService,
   ) { }
@@ -24,7 +24,7 @@ export class GlobalErrorHandler implements ErrorHandler {
       }
       if (error.status === 401) {
         console.log("401 response: " + JSON.stringify(error));
-        this._snackBar.open("Для выполнения этой операции необходимо залогиниться", 'Закрыть', {duration: 3000});
+        this.snackbar.error("Для выполнения этой операции необходимо залогиниться", 'Закрыть', 3000);
         this.authService.showLoginForm();
       } else {
         console.error(error);
@@ -35,11 +35,11 @@ export class GlobalErrorHandler implements ErrorHandler {
           const text = String(backendError.text ?? "");
           const description = String(backendError.description ?? "");
           const message = [typeText, text, description].filter(v => v.length > 0).join(": ");
-          this._snackBar.open(message || "Ошибка запроса", 'Закрыть', {duration: 5000});
+          this.snackbar.error(message || "Ошибка запроса", 'Закрыть');
           return;
         }
 
-        this._snackBar.open("Какая-то сетевая(?) ошибка=(", 'Закрыть', {duration: 3000});
+        this.snackbar.error("Какая-то сетевая(?) ошибка=(", 'Закрыть', 3000);
       }
     });
   }

--- a/src/app/profile/profile.component.ts
+++ b/src/app/profile/profile.component.ts
@@ -2,8 +2,8 @@ import {Component, OnInit} from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {NgIf} from '@angular/common';
 import {HttpErrorResponse} from '@angular/common/http';
-import {MatSnackBar} from '@angular/material/snack-bar';
 import {UserService} from '../auth/user.service';
+import {SnackbarService} from '../snackbar/snackbar.service';
 import {PushToggleComponent} from '../push/push-toggle.component';
 
 @Component({
@@ -20,7 +20,7 @@ export class ProfileComponent implements OnInit {
 
   constructor(
     private userService: UserService,
-    private snackBar: MatSnackBar,
+    private snackbar: SnackbarService,
   ) {
   }
 
@@ -40,12 +40,12 @@ export class ProfileComponent implements OnInit {
 
   changePassword() {
     if (!this.newPassword || !this.confirmPassword) {
-      this.snackBar.open('Заполните оба поля пароля', 'OK');
+      this.snackbar.error('Заполните оба поля пароля');
       return;
     }
 
     if (this.newPassword !== this.confirmPassword) {
-      this.snackBar.open('Пароли не совпадают', 'OK');
+      this.snackbar.error('Пароли не совпадают');
       return;
     }
 
@@ -56,16 +56,16 @@ export class ProfileComponent implements OnInit {
           this.newPassword = '';
           this.confirmPassword = '';
           this.isSubmitting = false;
-          this.snackBar.open('Пароль успешно изменён', 'OK');
+          this.snackbar.success('Пароль успешно изменён');
         },
         error: (err) => {
           this.isSubmitting = false;
           if (err instanceof HttpErrorResponse && err.status === 401) {
-            this.snackBar.open('Нужно войти в аккаунт', 'OK');
+            this.snackbar.error('Нужно войти в аккаунт');
             return;
           }
 
-          this.snackBar.open('Не удалось изменить пароль', 'OK');
+          this.snackbar.error('Не удалось изменить пароль');
         },
       });
   }

--- a/src/app/push/push.service.ts
+++ b/src/app/push/push.service.ts
@@ -1,8 +1,8 @@
 import {Injectable, NgZone, signal} from '@angular/core';
 import {Router} from '@angular/router';
-import {MatSnackBar} from '@angular/material/snack-bar';
 import {firstValueFrom} from 'rxjs';
 import {HttpAdapter} from '../http/http.adapter';
+import {SnackbarService} from '../snackbar/snackbar.service';
 
 export interface PushConfig {
   enabled: boolean;
@@ -41,7 +41,7 @@ export class PushService {
   constructor(
     private http: HttpAdapter,
     private router: Router,
-    private snackBar: MatSnackBar,
+    private snackbar: SnackbarService,
     private zone: NgZone,
   ) {
   }
@@ -85,7 +85,7 @@ export class PushService {
   async enable(): Promise<void> {
     if (!this.isSupported()) {
       this.state.set('unsupported');
-      this.notify('Этот браузер не поддерживает уведомления');
+      this.snackbar.error('Этот браузер не поддерживает уведомления');
       return;
     }
     if (this.busy()) {
@@ -97,7 +97,7 @@ export class PushService {
       const config = await this.loadConfig();
       if (!config.enabled || !config.public_key) {
         this.state.set('disabled');
-        this.notify('Push-уведомления сейчас отключены на сервере');
+        this.snackbar.info('Push-уведомления сейчас отключены на сервере');
         return;
       }
 
@@ -106,7 +106,7 @@ export class PushService {
       const permission = await Notification.requestPermission();
       if (permission !== 'granted') {
         this.state.set(permission === 'denied' ? 'denied' : 'default');
-        this.notify(
+        this.snackbar.error(
           permission === 'denied'
             ? 'Уведомления заблокированы в настройках браузера'
             : 'Разрешение на уведомления не получено',
@@ -117,10 +117,10 @@ export class PushService {
       const subscription = await this.subscribe(config.public_key);
       await this.sendSubscription(subscription);
       this.state.set('granted');
-      this.notify('Уведомления включены');
+      this.snackbar.success('Уведомления включены');
     } catch (e) {
       console.error('push: enable failed', e);
-      this.notify('Не удалось включить уведомления');
+      this.snackbar.error('Не удалось включить уведомления');
     } finally {
       this.busy.set(false);
     }
@@ -136,10 +136,10 @@ export class PushService {
     try {
       await this.removeSubscription();
       await this.syncState();
-      this.notify('Уведомления отключены');
+      this.snackbar.info('Уведомления отключены');
     } catch (e) {
       console.error('push: disable failed', e);
-      this.notify('Не удалось отключить уведомления');
+      this.snackbar.error('Не удалось отключить уведомления');
     } finally {
       this.busy.set(false);
     }
@@ -280,14 +280,10 @@ export class PushService {
   private showForegroundToast(payload: BackendPushPayload): void {
     const message = payload.body ? `${payload.title}: ${payload.body}` : payload.title;
     const url = payload.url || (payload.data?.['url'] as string | undefined);
-    const ref = this.snackBar.open(message, url ? 'Открыть' : 'OK', {duration: 6000});
+    const ref = this.snackbar.info(message, url ? 'Открыть' : 'OK', 6000);
     if (url) {
       ref.onAction().subscribe(() => this.router.navigateByUrl(url));
     }
-  }
-
-  private notify(message: string): void {
-    this.snackBar.open(message, 'OK', {duration: 4000});
   }
 }
 

--- a/src/app/snackbar/snackbar.service.ts
+++ b/src/app/snackbar/snackbar.service.ts
@@ -1,0 +1,33 @@
+import {Injectable} from '@angular/core';
+import {MatSnackBar, MatSnackBarRef, TextOnlySnackBar} from '@angular/material/snack-bar';
+
+export type SnackbarType = 'success' | 'error' | 'info';
+
+@Injectable({providedIn: 'root'})
+export class SnackbarService {
+  constructor(private snackBar: MatSnackBar) {}
+
+  success(message: string, action = 'OK', duration = 3000): MatSnackBarRef<TextOnlySnackBar> {
+    return this.show(message, action, duration, 'success');
+  }
+
+  error(message: string, action = 'OK', duration = 5000): MatSnackBarRef<TextOnlySnackBar> {
+    return this.show(message, action, duration, 'error');
+  }
+
+  info(message: string, action = 'OK', duration = 4000): MatSnackBarRef<TextOnlySnackBar> {
+    return this.show(message, action, duration, 'info');
+  }
+
+  private show(
+    message: string,
+    action: string,
+    duration: number,
+    type: SnackbarType,
+  ): MatSnackBarRef<TextOnlySnackBar> {
+    return this.snackBar.open(message, action, {
+      duration,
+      panelClass: [`snackbar-${type}`],
+    });
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -102,3 +102,27 @@ pre {
     transform: rotate(360deg);
   }
 }
+
+.snackbar-success .mdc-snackbar__surface {
+  background-color: #2e7d32 !important;
+}
+.snackbar-success .mdc-snackbar__label,
+.snackbar-success .mdc-snackbar__surface .mat-mdc-button {
+  color: #fff !important;
+}
+
+.snackbar-error .mdc-snackbar__surface {
+  background-color: #c62828 !important;
+}
+.snackbar-error .mdc-snackbar__label,
+.snackbar-error .mdc-snackbar__surface .mat-mdc-button {
+  color: #fff !important;
+}
+
+.snackbar-info .mdc-snackbar__surface {
+  background-color: #1565c0 !important;
+}
+.snackbar-info .mdc-snackbar__label,
+.snackbar-info .mdc-snackbar__surface .mat-mdc-button {
+  color: #fff !important;
+}


### PR DESCRIPTION
## Summary\n\n- Add centralized `SnackbarService` with typed methods: `success()` (green), `error()` (red), `info()` (blue)\n- Add global CSS styles for each snackbar type using `panelClass`\n- Migrate all 8 files from direct `MatSnackBar` usage to the new service, categorizing each message by type\n\n## Test plan\n\n- [ ] Trigger a success snackbar (e.g. change password successfully) — should appear green\n- [ ] Trigger an error snackbar (e.g. wrong credentials) — should appear red\n- [ ] Trigger an info snackbar (e.g. click game without auth) — should appear blue\n- [ ] Verify dark mode doesn't break snackbar visibility\n- [ ] Verify snackbar action buttons are readable on all color backgrounds\n\nCloses #68\n\nhttps://claude.ai/code/session_01Bi1zEjzMU3QLsig9GGTioK

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bi1zEjzMU3QLsig9GGTioK)_