### PR TITLE
Add games constructor for creating and editing games

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -5,12 +5,16 @@ import {GameComponent} from "./game/game.component";
 import {GamePlayComponent} from "./game_play/game_play.component";
 import {ProfileComponent} from "./profile/profile.component";
 import {OneTimeTokenComponent} from "./auth/one-time-token.component";
+import {ConstructorComponent} from "./constructor/constructor.component";
+import {GameEditorComponent} from "./constructor/game-editor.component";
 
 
 export const routes: Routes = [
   {path: "", component: HomeComponent},
   {path: "games", component: GamesComponent},
   {path: "games/running", component: GamePlayComponent},
+  {path: "games/constructor", component: ConstructorComponent},
+  {path: "games/constructor/:id", component: GameEditorComponent},
   {path: "games/:id", component: GameComponent},
   {path: "profile", component: ProfileComponent},
   {path: "auth/one-time-token", component: OneTimeTokenComponent},

--- a/src/app/auth/user.service.ts
+++ b/src/app/auth/user.service.ts
@@ -8,6 +8,7 @@ import {AuthStateService} from "./auth-state.service";
 export class UserData {
   id: number | undefined;
   name_mention: string | undefined;
+  can_be_author: boolean | undefined;
 }
 
 @Injectable({
@@ -52,6 +53,11 @@ export class UserService {
 
   public isUserLoaded() {
     return this.me !== undefined;
+  }
+
+  public canBeAuthor() {
+    // Show author tools unless the backend explicitly says the user can't.
+    return this.me !== undefined && this.me.can_be_author !== false;
   }
 
   public clearUser() {

--- a/src/app/constructor/constructor.component.html
+++ b/src/app/constructor/constructor.component.html
@@ -1,0 +1,45 @@
+<section class="constructor-page">
+  <h1>Конструктор игр</h1>
+
+  @if (!isAuthenticated) {
+    <p>Авторизуйтесь, чтобы создавать и редактировать игры.</p>
+  } @else {
+    <form class="create-form" (ngSubmit)="createGame()">
+      <label for="newGameName">Название новой игры</label>
+      <div class="create-row">
+        <input
+          id="newGameName"
+          name="newGameName"
+          type="text"
+          placeholder="Например: Ночная Схватка №42"
+          [(ngModel)]="newGameName"
+        />
+        <button class="primary" type="submit" [disabled]="isCreating">
+          {{ isCreating ? "Создаём..." : "Создать" }}
+        </button>
+      </div>
+    </form>
+
+    <h2 class="drafts-title">Мои черновики</h2>
+
+    @if (isLoading) {
+      <div class="loading-state" aria-live="polite">
+        <span class="loading-spinner"></span>
+        Загрузка...
+      </div>
+    } @else if (games && games.length > 0) {
+      <ul class="games-list">
+        @for (game of games; track game.id) {
+          <li class="games-list-item">
+            <a [routerLink]="['/games/constructor', game.id]">
+              <div class="game-name"><span>{{ game.name }}</span></div>
+              <div class="game-status">{{ statusLabel(game.status) }}</div>
+            </a>
+          </li>
+        }
+      </ul>
+    } @else {
+      <p class="empty-state">У вас пока нет игр-черновиков. Создайте первую выше.</p>
+    }
+  }
+</section>

--- a/src/app/constructor/constructor.component.scss
+++ b/src/app/constructor/constructor.component.scss
@@ -1,0 +1,92 @@
+@use "../../styles/component-mixins" as cm;
+
+.constructor-page {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+h1 {
+  margin-top: 0;
+  color: inherit;
+}
+
+.create-form {
+  @include cm.surface-card(16px, 1rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+label {
+  font-size: 0.9rem;
+  color: inherit;
+}
+
+.create-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.create-row input {
+  @include cm.input-control();
+  flex: 1;
+}
+
+.primary {
+  @include cm.button-base();
+  background: var(--app-accent);
+  color: var(--app-accent-contrast);
+  white-space: nowrap;
+}
+
+.primary:disabled {
+  opacity: 0.7;
+  cursor: wait;
+}
+
+.drafts-title {
+  font-size: 1.1rem;
+  color: inherit;
+}
+
+.games-list {
+  list-style: none;
+  padding-left: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.games-list-item {
+  @include cm.surface-card(12px, 0);
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.games-list-item:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 22px rgba(16, 24, 40, 0.08);
+}
+
+.games-list-item a {
+  text-decoration: none;
+  color: var(--app-text);
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.8rem 1rem;
+}
+
+.game-status {
+  font-size: 0.85rem;
+  color: var(--app-muted-text);
+  background: color-mix(in srgb, var(--app-surface) 70%, var(--app-accent));
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.empty-state {
+  color: var(--app-muted-text);
+}

--- a/src/app/constructor/constructor.component.ts
+++ b/src/app/constructor/constructor.component.ts
@@ -1,0 +1,81 @@
+import {Component, OnInit} from "@angular/core";
+import {FormsModule} from "@angular/forms";
+import {Router, RouterLink} from "@angular/router";
+import {ConstructorService} from "./constructor.service";
+import {MyGame, STATUS_LABELS} from "./constructor.models";
+import {UserService} from "../auth/user.service";
+import {SnackbarService} from "../snackbar/snackbar.service";
+
+@Component({
+  selector: "app-constructor",
+  standalone: true,
+  imports: [FormsModule, RouterLink],
+  templateUrl: "./constructor.component.html",
+  styleUrl: "./constructor.component.scss",
+})
+export class ConstructorComponent implements OnInit {
+  games: MyGame[] | undefined;
+  isLoading = false;
+  newGameName = "";
+  isCreating = false;
+
+  constructor(
+    private constructorService: ConstructorService,
+    private userService: UserService,
+    private snackbar: SnackbarService,
+    private router: Router,
+  ) {
+  }
+
+  async ngOnInit() {
+    if (!this.userService.isUserLoaded()) {
+      await this.userService.loadMe();
+    }
+    if (this.isAuthenticated) {
+      this.loadGames();
+    }
+  }
+
+  get isAuthenticated(): boolean {
+    return this.userService.isUserLoaded();
+  }
+
+  loadGames() {
+    this.isLoading = true;
+    this.constructorService.listMyGames().subscribe({
+      next: page => {
+        this.games = page.content ?? [];
+        this.isLoading = false;
+      },
+      error: () => {
+        this.games = [];
+        this.isLoading = false;
+      },
+    });
+  }
+
+  statusLabel(status: string): string {
+    return STATUS_LABELS[status] ?? status;
+  }
+
+  createGame() {
+    const name = this.newGameName.trim();
+    if (!name) {
+      this.snackbar.error("Введите название игры");
+      return;
+    }
+
+    this.isCreating = true;
+    this.constructorService.createGame(name).subscribe({
+      next: game => {
+        this.isCreating = false;
+        this.newGameName = "";
+        this.snackbar.success("Игра создана");
+        this.router.navigate(["/games/constructor", game.id]);
+      },
+      error: () => {
+        this.isCreating = false;
+      },
+    });
+  }
+}

--- a/src/app/constructor/constructor.models.ts
+++ b/src/app/constructor/constructor.models.ts
@@ -1,4 +1,5 @@
 import {HintType, ScenarioConditionType} from "../domain/game.models";
+import {HttpErrorResponse} from "@angular/common/http";
 
 // ---------------------------------------------------------------------------
 // Constructor payload model — mirrors the "Game Scenario object" contract (§2).
@@ -250,6 +251,24 @@ export function parseKeys(raw: string): string[] {
     .map(p => p.trim().toUpperCase())
     .filter(p => p.length > 0);
   return Array.from(new Set(parts));
+}
+
+/** Human readable (ru) description of a request error, for snackbars. */
+export function describeError(err: unknown): string {
+  if (err instanceof HttpErrorResponse) {
+    if (err.status === 0) {
+      return "сервер недоступен";
+    }
+    const body = err.error as { type?: unknown; description?: unknown; text?: unknown } | null;
+    if (body && typeof body === "object") {
+      const type = String(body.type ?? "");
+      const description = String(body.description ?? body.text ?? "");
+      const parts = [type, description].filter(s => s.length > 0).join(": ");
+      return `[${err.status}] ${parts || "ошибка запроса"}`;
+    }
+    return `[${err.status}] ${err.statusText || "ошибка запроса"}`;
+  }
+  return "неизвестная ошибка";
 }
 
 export function generateEffectId(): string {

--- a/src/app/constructor/constructor.models.ts
+++ b/src/app/constructor/constructor.models.ts
@@ -321,6 +321,9 @@ export function validateScenario(scenario: ScenarioPayload): string[] {
     // §2 — unique times, non-empty hint lists
     const seenTimes = new Set<number>();
     level.time_hints.forEach(th => {
+      if (th.time < 0) {
+        errors.push(`${label}: время подсказки не может быть отрицательным (${th.time}).`);
+      }
       if (seenTimes.has(th.time)) {
         errors.push(`${label}: время ${th.time} повторяется в подсказках.`);
       }
@@ -384,6 +387,8 @@ export function validateScenario(scenario: ScenarioPayload): string[] {
       if (c.type === ScenarioConditionType.effectsTimer) {
         if (typeof c.action_time !== "number") {
           errors.push(`${cl}: не задано время срабатывания таймера.`);
+        } else if (c.action_time < 0) {
+          errors.push(`${cl}: время таймера не может быть отрицательным (${c.action_time}).`);
         } else if (timerTimes.has(c.action_time)) {
           errors.push(`${cl}: два таймера на одно время (${c.action_time}).`);
         } else {

--- a/src/app/constructor/constructor.models.ts
+++ b/src/app/constructor/constructor.models.ts
@@ -149,6 +149,23 @@ export const ALL_HINT_TYPES: HintType[] = [
   HintType.sticker,
 ];
 
+/**
+ * Hint types that can be created from the web constructor. Sticker, voice and
+ * video_note are intentionally excluded — we cannot upload those from the web.
+ * Existing hints of those types still render/edit, they just can't be added.
+ */
+export const CREATABLE_HINT_TYPES: HintType[] = [
+  HintType.text,
+  HintType.gps,
+  HintType.venue,
+  HintType.photo,
+  HintType.audio,
+  HintType.video,
+  HintType.document,
+  HintType.animation,
+  HintType.contact,
+];
+
 /** Hint types that carry a main file (`file_guid`). */
 export const FILE_HINT_TYPES: HintType[] = [
   HintType.photo,

--- a/src/app/constructor/constructor.models.ts
+++ b/src/app/constructor/constructor.models.ts
@@ -1,0 +1,411 @@
+import {HintType, ScenarioConditionType} from "../domain/game.models";
+
+// ---------------------------------------------------------------------------
+// Constructor payload model — mirrors the "Game Scenario object" contract (§2).
+// All fields are snake_case so the objects can be round-tripped (load → edit →
+// save) without any key conversion.
+// ---------------------------------------------------------------------------
+
+export const SCENARIO_MODEL_VERSION = 1;
+
+export interface MyGameAuthor {
+  id: number;
+  can_be_author: boolean;
+  name_mention: string;
+}
+
+/** Item shape of `GET /games/my` and `POST /games/my` (§1.1). */
+export interface MyGame {
+  id: number;
+  author: MyGameAuthor;
+  name: string;
+  status: string;
+  start_at: string | null;
+  number: number | null;
+}
+
+/** Upload response of `POST /cdn/games/{id}/files` (§1.7). */
+export interface UploadedFile {
+  guid: string;
+  original_filename: string;
+  extension: string;
+  content_type?: string;
+  mime_type?: string;
+  sha256?: string;
+}
+
+export interface LinkPreview {
+  is_disabled?: boolean;
+  url?: string;
+  prefer_small_media?: boolean;
+  prefer_large_media?: boolean;
+  show_above_text?: boolean;
+}
+
+/** Hint, discriminated by `type` (§2.3). Only the fields relevant to the
+ *  selected type are sent; the rest stay undefined. */
+export interface HintPayload {
+  type: HintType;
+  // text
+  text?: string;
+  link_preview?: LinkPreview | null;
+  // gps / venue
+  latitude?: number;
+  longitude?: number;
+  // venue
+  title?: string;
+  address?: string;
+  foursquare_id?: string;
+  foursquare_type?: string;
+  // media
+  caption?: string;
+  show_caption_above_media?: boolean;
+  file_guid?: string;
+  thumb_guid?: string;
+  // contact
+  phone_number?: string;
+  first_name?: string;
+  last_name?: string;
+  vcard?: string;
+}
+
+export interface TimeHintPayload {
+  time: number;
+  hint: HintPayload[];
+}
+
+/** Effects (§2.5). A single object per effects condition. */
+export interface EffectsPayload {
+  id: string;
+  hints: HintPayload[];
+  bonus_minutes: number;
+  level_up: boolean;
+  next_level: string | null;
+}
+
+/** Condition, discriminated by `type` (§2.4). */
+export interface ConditionPayload {
+  type: ScenarioConditionType;
+  keys?: string[];
+  action_time?: number;
+  effects?: EffectsPayload;
+}
+
+export interface LevelPayload {
+  id: string;
+  __model_version__: number;
+  conditions: ConditionPayload[];
+  time_hints: TimeHintPayload[];
+}
+
+export interface FilePayload {
+  guid: string;
+  original_filename: string;
+  extension: string;
+  content_type?: string;
+  mime_type?: string;
+  sha256?: string;
+}
+
+/** Body of `PUT /games/my/{id}/scenario` (§2). */
+export interface ScenarioPayload {
+  name: string;
+  __model_version__: number;
+  levels: LevelPayload[];
+  files: FilePayload[];
+}
+
+// ---------------------------------------------------------------------------
+// Constants for UI rendering
+// ---------------------------------------------------------------------------
+
+export const HINT_TYPE_LABELS: Record<HintType, string> = {
+  [HintType.text]: "Текст",
+  [HintType.gps]: "Координаты (GPS)",
+  [HintType.venue]: "Место (venue)",
+  [HintType.photo]: "Фото",
+  [HintType.audio]: "Аудио",
+  [HintType.video]: "Видео",
+  [HintType.document]: "Документ",
+  [HintType.animation]: "Анимация (GIF)",
+  [HintType.voice]: "Голосовое",
+  [HintType.video_note]: "Видеосообщение (кружок)",
+  [HintType.contact]: "Контакт",
+  [HintType.sticker]: "Стикер",
+};
+
+export const ALL_HINT_TYPES: HintType[] = [
+  HintType.text,
+  HintType.gps,
+  HintType.venue,
+  HintType.photo,
+  HintType.audio,
+  HintType.video,
+  HintType.document,
+  HintType.animation,
+  HintType.voice,
+  HintType.video_note,
+  HintType.contact,
+  HintType.sticker,
+];
+
+/** Hint types that carry a main file (`file_guid`). */
+export const FILE_HINT_TYPES: HintType[] = [
+  HintType.photo,
+  HintType.audio,
+  HintType.video,
+  HintType.document,
+  HintType.animation,
+  HintType.voice,
+  HintType.video_note,
+  HintType.sticker,
+];
+
+/** Hint types that may carry an optional thumbnail (`thumb_guid`). */
+export const THUMB_HINT_TYPES: HintType[] = [
+  HintType.audio,
+  HintType.video,
+  HintType.document,
+  HintType.animation,
+];
+
+/** Hint types that support a caption. */
+export const CAPTION_HINT_TYPES: HintType[] = [
+  HintType.photo,
+  HintType.audio,
+  HintType.video,
+  HintType.document,
+  HintType.animation,
+  HintType.voice,
+];
+
+/** Hint types that support `show_caption_above_media`. */
+export const CAPTION_ABOVE_HINT_TYPES: HintType[] = [
+  HintType.photo,
+  HintType.video,
+  HintType.animation,
+];
+
+export const STATUS_LABELS: Record<string, string> = {
+  underconstruction: "В разработке",
+  ready: "Готова",
+  getting_waivers: "Сбор вейверов",
+  started: "Идёт",
+  finished: "Завершена",
+  complete: "Опубликована",
+};
+
+export const EDITABLE_STATUSES = ["underconstruction", "ready", "getting_waivers"];
+
+export function isEditableStatus(status: string | undefined): boolean {
+  return !!status && EDITABLE_STATUSES.includes(status);
+}
+
+// ---------------------------------------------------------------------------
+// Key format (§2.6): start with Latin SH or Cyrillic СХ, then uppercase
+// letters/digits (Latin or Cyrillic). No lowercase, no spaces.
+// ---------------------------------------------------------------------------
+
+const KEY_REGEX = /^(SH|СХ)[A-Z0-9А-ЯЁ]+$/;
+const LEVEL_ID_REGEX = /^[a-zA-Z0-9_-]+$/;
+
+export function isValidKey(key: string): boolean {
+  return KEY_REGEX.test(key);
+}
+
+export function isValidLevelId(id: string): boolean {
+  return LEVEL_ID_REGEX.test(id);
+}
+
+/** Parse a free-text keys field (separated by spaces / commas / newlines)
+ *  into a normalized, uppercased list of unique keys. */
+export function parseKeys(raw: string): string[] {
+  const parts = raw
+    .split(/[\s,;]+/)
+    .map(p => p.trim().toUpperCase())
+    .filter(p => p.length > 0);
+  return Array.from(new Set(parts));
+}
+
+export function generateEffectId(): string {
+  const c = globalThis.crypto as Crypto | undefined;
+  if (c && typeof c.randomUUID === "function") {
+    return c.randomUUID();
+  }
+  // Fallback (non-cryptographic) for environments without crypto.randomUUID.
+  return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, ch => {
+    const r = (Math.random() * 16) | 0;
+    const v = ch === "x" ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Client-side validation of the scenario (§3). The server enforces all of
+// these regardless; we validate locally for good UX. Returns a list of human
+// readable (ru) error messages — empty list means valid.
+// ---------------------------------------------------------------------------
+
+function isWinningTimer(c: ConditionPayload): boolean {
+  return c.type === ScenarioConditionType.effectsTimer && c.effects?.level_up === true;
+}
+
+function collectGuids(hints: HintPayload[] | undefined, sink: Set<string>) {
+  for (const hint of hints ?? []) {
+    if (hint.file_guid) {
+      sink.add(hint.file_guid);
+    }
+    if (hint.thumb_guid) {
+      sink.add(hint.thumb_guid);
+    }
+  }
+}
+
+export function validateScenario(scenario: ScenarioPayload): string[] {
+  const errors: string[] = [];
+
+  if (!scenario.name || scenario.name.trim().length === 0) {
+    errors.push("Название игры не может быть пустым.");
+  }
+
+  if (scenario.levels.length === 0) {
+    errors.push("В игре должен быть хотя бы один уровень.");
+  }
+
+  const levelIds = scenario.levels.map(l => l.id);
+  const knownFileGuids = new Set(scenario.files.map(f => f.guid));
+  const usedGuids = new Set<string>();
+
+  scenario.levels.forEach((level, index) => {
+    const label = `Уровень ${index + 1}${level.id ? ` (${level.id})` : ""}`;
+
+    // §13 — level id format
+    if (!isValidLevelId(level.id)) {
+      errors.push(`${label}: идентификатор уровня должен соответствовать ^[a-zA-Z0-9_-]+$.`);
+    }
+    if (levelIds.indexOf(level.id) !== index) {
+      errors.push(`${label}: идентификатор уровня повторяется.`);
+    }
+
+    // time_hints
+    const times = level.time_hints.map(t => t.time);
+    // §1 — must include time 0
+    if (!times.includes(0)) {
+      errors.push(`${label}: должна быть подсказка для времени 0.`);
+    }
+    // §2 — unique times, non-empty hint lists
+    const seenTimes = new Set<number>();
+    level.time_hints.forEach(th => {
+      if (seenTimes.has(th.time)) {
+        errors.push(`${label}: время ${th.time} повторяется в подсказках.`);
+      }
+      seenTimes.add(th.time);
+      if (!th.hint || th.hint.length === 0) {
+        errors.push(`${label}: у подсказки на время ${th.time} пустой список.`);
+      }
+      collectGuids(th.hint, usedGuids);
+    });
+
+    // conditions
+    // §4 — non-empty
+    if (level.conditions.length === 0) {
+      errors.push(`${label}: должно быть хотя бы одно условие.`);
+    }
+
+    const winKeys = level.conditions.filter(c => c.type === ScenarioConditionType.winKey);
+    const winningTimers = level.conditions.filter(isWinningTimer);
+    const hasWin = winKeys.length > 0
+      || level.conditions.some(c =>
+        (c.type === ScenarioConditionType.effectsKey || c.type === ScenarioConditionType.effectsTimer)
+        && c.effects?.level_up === true);
+
+    // §5 — at least one win
+    if (!hasWin) {
+      errors.push(`${label}: нет условия победы (WIN_KEY или эффект с переходом на уровень).`);
+    }
+    // §6 — at most one WIN_KEY
+    if (winKeys.length > 1) {
+      errors.push(`${label}: допускается не более одного условия WIN_KEY.`);
+    }
+    // §7 — at most one winning timer
+    if (winningTimers.length > 1) {
+      errors.push(`${label}: допускается не более одного победного таймера.`);
+    }
+
+    // §8 — keys globally unique within a level
+    const keySeen = new Set<string>();
+    // §9 — effect ids unique within a level
+    const effectIds = new Set<string>();
+    // §10 — timer action_times unique
+    const timerTimes = new Set<number>();
+
+    level.conditions.forEach((c, ci) => {
+      const cl = `${label}, условие ${ci + 1}`;
+      if (c.type === ScenarioConditionType.winKey || c.type === ScenarioConditionType.effectsKey) {
+        const keys = c.keys ?? [];
+        if (keys.length === 0) {
+          errors.push(`${cl}: список ключей пуст.`);
+        }
+        keys.forEach(k => {
+          if (!isValidKey(k)) {
+            errors.push(`${cl}: ключ «${k}» имеет неверный формат.`);
+          }
+          if (keySeen.has(k)) {
+            errors.push(`${cl}: ключ «${k}» используется в нескольких условиях уровня.`);
+          }
+          keySeen.add(k);
+        });
+      }
+      if (c.type === ScenarioConditionType.effectsTimer) {
+        if (typeof c.action_time !== "number") {
+          errors.push(`${cl}: не задано время срабатывания таймера.`);
+        } else if (timerTimes.has(c.action_time)) {
+          errors.push(`${cl}: два таймера на одно время (${c.action_time}).`);
+        } else {
+          timerTimes.add(c.action_time);
+        }
+      }
+      if (c.effects) {
+        if (effectIds.has(c.effects.id)) {
+          errors.push(`${cl}: идентификатор эффекта повторяется в уровне.`);
+        }
+        effectIds.add(c.effects.id);
+        // next_level requires level_up
+        if (c.effects.next_level && !c.effects.level_up) {
+          errors.push(`${cl}: переход на другой уровень требует включённого «победа/переход».`);
+        }
+        // §12 — next_level must exist
+        if (c.effects.next_level && !levelIds.includes(c.effects.next_level)) {
+          errors.push(`${cl}: уровень перехода «${c.effects.next_level}» не существует.`);
+        }
+        collectGuids(c.effects.hints, usedGuids);
+      }
+    });
+
+    // §3 / §11 — winning timer constraints
+    if (winningTimers.length === 1) {
+      const winTime = winningTimers[0].action_time;
+      if (typeof winTime === "number") {
+        times.forEach(t => {
+          if (t >= winTime) {
+            errors.push(`${label}: время подсказки ${t} должно быть строго меньше времени победного таймера (${winTime}).`);
+          }
+        });
+        timerTimes.forEach(t => {
+          if (t > winTime) {
+            errors.push(`${label}: таймер на время ${t} превышает время победного таймера (${winTime}).`);
+          }
+        });
+      }
+    }
+  });
+
+  // §14 — every used guid must be present in the files array
+  usedGuids.forEach(guid => {
+    if (!knownFileGuids.has(guid)) {
+      errors.push(`Файл ${guid} используется в подсказке, но отсутствует в списке файлов. Загрузите его заново.`);
+    }
+  });
+
+  return errors;
+}

--- a/src/app/constructor/constructor.models.ts
+++ b/src/app/constructor/constructor.models.ts
@@ -186,6 +186,14 @@ export const CAPTION_ABOVE_HINT_TYPES: HintType[] = [
   HintType.animation,
 ];
 
+/** Labels for the CDN `content_type` of an uploaded file. */
+export const CONTENT_TYPE_LABELS: Record<string, string> = {
+  photo: "Фото",
+  video: "Видео",
+  audio: "Аудио",
+  document: "Документ",
+};
+
 export const STATUS_LABELS: Record<string, string> = {
   underconstruction: "В разработке",
   ready: "Готова",

--- a/src/app/constructor/constructor.service.ts
+++ b/src/app/constructor/constructor.service.ts
@@ -1,0 +1,51 @@
+import {Injectable} from "@angular/core";
+import {Observable} from "rxjs";
+import {HttpAdapter} from "../http/http.adapter";
+import {Page} from "../games/games.service";
+import {FullGame} from "../domain/game.models";
+import {MyGame, ScenarioPayload, UploadedFile} from "./constructor.models";
+
+@Injectable({
+  providedIn: "root",
+})
+export class ConstructorService {
+  constructor(private http: HttpAdapter) {
+  }
+
+  /** §1.1 — list the current author's game drafts (not complete). */
+  listMyGames(): Observable<Page<MyGame>> {
+    return this.http.get<Page<MyGame>>("/games/my");
+  }
+
+  /** §1.2 — full game by id for editing. */
+  getGame(id: number): Observable<FullGame> {
+    return this.http.get<FullGame>(`/games/my/${id}`);
+  }
+
+  /** §1.3 — create a new draft. */
+  createGame(name: string): Observable<MyGame> {
+    return this.http.post<MyGame>("/games/my", {name});
+  }
+
+  /** §1.4 — replace the whole scenario. */
+  saveScenario(id: number, scenario: ScenarioPayload): Observable<FullGame> {
+    return this.http.put<FullGame>(`/games/my/${id}/scenario`, scenario);
+  }
+
+  /** §1.5 — set or clear the planned start. */
+  setStartAt(id: number, startAt: string | null): Observable<MyGame> {
+    return this.http.put<MyGame>(`/games/my/${id}/start_at`, {start_at: startAt});
+  }
+
+  /** §1.6 — change status. */
+  setStatus(id: number, status: string): Observable<MyGame> {
+    return this.http.put<MyGame>(`/games/my/${id}/status`, {status});
+  }
+
+  /** §1.7 — upload a single file (multipart `file`). */
+  uploadFile(id: number, file: File): Observable<UploadedFile> {
+    const formData = new FormData();
+    formData.append("file", file);
+    return this.http.postCdnForm<UploadedFile>(`/games/${id}/files`, formData);
+  }
+}

--- a/src/app/constructor/effects-editor.component.html
+++ b/src/app/constructor/effects-editor.component.html
@@ -1,15 +1,17 @@
 <div class="effects-editor">
   <div class="effects-row">
     <div class="bonus-field">
-      <label>{{ AppEmoji.bonus }} Бонус минут (±)</label>
-      <input type="number" step="any" [(ngModel)]="effects.bonus_minutes" [disabled]="disabled" />
+      <label>{{ AppEmoji.bonus }} Бонус минут</label>
+      <input type="number" step="any" [(ngModel)]="effects.bonus_minutes" [disabled]="disabled" title="+ бонус, − штраф" />
+      <span class="field-hint">+ бонус, − штраф</span>
     </div>
 
     @if (allowLevelUp) {
       <div class="level-up-row">
-        <label class="checkbox">
+        <label class="toggle" [class.disabled]="disabled">
           <input type="checkbox" [(ngModel)]="effects.level_up" (ngModelChange)="onLevelUpChange()" [disabled]="disabled" />
-          {{ AppEmoji.levelUp }} Завершение уровня
+          <span class="toggle-track"><span class="toggle-thumb"></span></span>
+          <span class="toggle-label">{{ AppEmoji.levelUp }} Завершение уровня</span>
         </label>
         @if (effects.level_up) {
           <select [(ngModel)]="effects.next_level" [disabled]="disabled" title="Переход на уровень">

--- a/src/app/constructor/effects-editor.component.html
+++ b/src/app/constructor/effects-editor.component.html
@@ -37,6 +37,7 @@
         [hint]="h"
         [files]="files"
         [gameId]="gameId"
+        [objectUrls]="objectUrls"
         [disabled]="disabled"
         (remove)="removeHint(hi)"
         (fileUploaded)="onFileUploaded($event)"

--- a/src/app/constructor/effects-editor.component.html
+++ b/src/app/constructor/effects-editor.component.html
@@ -1,0 +1,44 @@
+<div class="effects-editor">
+  <div class="effects-row">
+    <div class="bonus-field">
+      <label>{{ AppEmoji.bonus }} Бонус минут (±)</label>
+      <input type="number" step="any" [(ngModel)]="effects.bonus_minutes" [disabled]="disabled" />
+    </div>
+
+    @if (allowLevelUp) {
+      <div class="level-up-row">
+        <label class="checkbox">
+          <input type="checkbox" [(ngModel)]="effects.level_up" (ngModelChange)="onLevelUpChange()" [disabled]="disabled" />
+          {{ AppEmoji.levelUp }} Завершение уровня
+        </label>
+        @if (effects.level_up) {
+          <select [(ngModel)]="effects.next_level" [disabled]="disabled" title="Переход на уровень">
+            <option [ngValue]="null">{{ AppEmoji.jump }} следующий по порядку</option>
+            @for (id of levelIds; track id) {
+              <option [ngValue]="id">{{ AppEmoji.jump }} {{ id }}</option>
+            }
+          </select>
+        }
+      </div>
+    }
+  </div>
+
+  <div class="effect-hints">
+    <div class="hints-head">
+      <span>{{ AppEmoji.bonusHint }} Бонусные подсказки</span>
+      @if (!disabled) {
+        <app-hint-type-picker (picked)="addHint($event)"></app-hint-type-picker>
+      }
+    </div>
+    @for (h of effects.hints; track h; let hi = $index) {
+      <app-hint-editor
+        [hint]="h"
+        [files]="files"
+        [gameId]="gameId"
+        [disabled]="disabled"
+        (remove)="removeHint(hi)"
+        (fileUploaded)="onFileUploaded($event)"
+      ></app-hint-editor>
+    }
+  </div>
+</div>

--- a/src/app/constructor/effects-editor.component.scss
+++ b/src/app/constructor/effects-editor.component.scss
@@ -24,6 +24,11 @@
   width: 8rem;
 }
 
+.field-hint {
+  font-size: 0.78rem;
+  color: var(--app-muted-text);
+}
+
 label {
   font-size: 0.85rem;
   color: var(--app-muted-text);
@@ -36,13 +41,65 @@ label {
   flex-wrap: wrap;
 }
 
-label.checkbox {
-  display: flex;
+// Toggle switch
+.toggle {
+  display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  color: inherit;
+  gap: 0.5rem;
   margin: 0;
+  cursor: pointer;
+  color: inherit;
   white-space: nowrap;
+}
+
+.toggle.disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggle-track {
+  position: relative;
+  width: 2.4rem;
+  height: 1.35rem;
+  border-radius: 999px;
+  background: var(--app-border);
+  transition: background 0.15s ease;
+  flex: none;
+}
+
+.toggle-thumb {
+  position: absolute;
+  top: 0.15rem;
+  left: 0.15rem;
+  width: 1.05rem;
+  height: 1.05rem;
+  border-radius: 50%;
+  background: #fff;
+  transition: transform 0.15s ease;
+}
+
+.toggle input:checked + .toggle-track {
+  background: var(--app-accent);
+}
+
+.toggle input:checked + .toggle-track .toggle-thumb {
+  transform: translateX(1.05rem);
+}
+
+.toggle input:focus-visible + .toggle-track {
+  outline: 2px solid var(--app-accent);
+  outline-offset: 2px;
+}
+
+.toggle-label {
+  font-size: 0.9rem;
 }
 
 .level-up-row select {

--- a/src/app/constructor/effects-editor.component.scss
+++ b/src/app/constructor/effects-editor.component.scss
@@ -39,6 +39,9 @@ label {
   align-items: center;
   gap: 0.6rem;
   flex-wrap: wrap;
+  // Reserve the select's height so the toggle doesn't jump when next_level
+  // appears/disappears.
+  min-height: 2.6rem;
 }
 
 // Toggle switch

--- a/src/app/constructor/effects-editor.component.scss
+++ b/src/app/constructor/effects-editor.component.scss
@@ -118,7 +118,7 @@ label {
 .hints-head {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.5rem;
+  gap: 0.6rem;
   font-size: 0.9rem;
+  flex-wrap: wrap;
 }

--- a/src/app/constructor/effects-editor.component.scss
+++ b/src/app/constructor/effects-editor.component.scss
@@ -1,0 +1,64 @@
+@use "../../styles/component-mixins" as cm;
+
+.effects-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.effects-row {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-end;
+  flex-wrap: wrap;
+}
+
+.bonus-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.bonus-field input {
+  @include cm.input-control();
+  width: 8rem;
+}
+
+label {
+  font-size: 0.85rem;
+  color: var(--app-muted-text);
+}
+
+.level-up-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+label.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: inherit;
+  margin: 0;
+  white-space: nowrap;
+}
+
+.level-up-row select {
+  @include cm.input-control();
+}
+
+.effect-hints {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hints-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}

--- a/src/app/constructor/effects-editor.component.ts
+++ b/src/app/constructor/effects-editor.component.ts
@@ -1,0 +1,46 @@
+import {Component, EventEmitter, Input, Output} from "@angular/core";
+import {FormsModule} from "@angular/forms";
+import {HintType} from "../domain/game.models";
+import {EffectsPayload, UploadedFile} from "./constructor.models";
+import {HintEditorComponent} from "./hint-editor.component";
+import {HintTypePickerComponent} from "./hint-type-picker.component";
+import {AppEmoji} from "../ui/emoji";
+
+@Component({
+  selector: "app-effects-editor",
+  standalone: true,
+  imports: [FormsModule, HintEditorComponent, HintTypePickerComponent],
+  templateUrl: "./effects-editor.component.html",
+  styleUrl: "./effects-editor.component.scss",
+})
+export class EffectsEditorComponent {
+  @Input({required: true}) effects!: EffectsPayload;
+  @Input() files: UploadedFile[] = [];
+  @Input() gameId: number | undefined;
+  @Input() disabled = false;
+  /** Whether the level-up ("завершение уровня") toggle is shown. */
+  @Input() allowLevelUp = true;
+  /** Ids of the other levels — targets for the next_level jump. */
+  @Input() levelIds: string[] = [];
+  @Output() fileUploaded = new EventEmitter<UploadedFile>();
+
+  protected readonly AppEmoji = AppEmoji;
+
+  onLevelUpChange() {
+    if (!this.effects.level_up) {
+      this.effects.next_level = null;
+    }
+  }
+
+  addHint(type: HintType) {
+    this.effects.hints.push({type});
+  }
+
+  removeHint(index: number) {
+    this.effects.hints.splice(index, 1);
+  }
+
+  onFileUploaded(file: UploadedFile) {
+    this.fileUploaded.emit(file);
+  }
+}

--- a/src/app/constructor/effects-editor.component.ts
+++ b/src/app/constructor/effects-editor.component.ts
@@ -17,6 +17,7 @@ export class EffectsEditorComponent {
   @Input({required: true}) effects!: EffectsPayload;
   @Input() files: UploadedFile[] = [];
   @Input() gameId: number | undefined;
+  @Input() objectUrls?: Map<string, string>;
   @Input() disabled = false;
   /** Whether the level-up ("завершение уровня") toggle is shown. */
   @Input() allowLevelUp = true;

--- a/src/app/constructor/game-editor.component.html
+++ b/src/app/constructor/game-editor.component.html
@@ -24,158 +24,183 @@
       <input id="gameName" type="text" [(ngModel)]="name" [disabled]="!isEditable" />
     </div>
 
-    <!-- Files -->
-    <div class="block">
-      <h2>Файлы</h2>
-      <p class="hint-note">Загрузите медиа заранее, затем выбирайте их в подсказках.</p>
-      @if (files.length > 0) {
-        <ul class="files-list">
-          @for (f of files; track f.guid) {
-            <li>
-              <span class="file-name">{{ fileLabel(f) }}</span>
-              <span class="file-guid">{{ f.guid }}</span>
-            </li>
-          }
-        </ul>
-      }
-      @if (isEditable) {
-        <label class="upload-control">
-          <input type="file" (change)="onFileSelected($event)" [disabled]="isUploading" />
-        </label>
-        @if (isUploading) {
-          <span class="hint-note">Загрузка файла...</span>
-        }
-      }
-    </div>
-
     <!-- Levels -->
     <div class="block">
       <div class="block-head">
-        <h2>Уровни</h2>
+        <h2>{{ AppEmoji.level }} Уровни</h2>
         @if (isEditable) {
           <button type="button" class="primary" (click)="addLevel()">+ Уровень</button>
         }
       </div>
 
       @for (level of levels; track level; let li = $index) {
-        <div class="level-card">
-          <div class="level-head">
-            <div class="level-id">
-              <label>ID уровня #{{ li + 1 }}</label>
-              <input type="text" [(ngModel)]="level.id" [disabled]="!isEditable" />
-            </div>
-            @if (isEditable) {
-              <div class="level-actions">
-                <button type="button" class="ghost-button" (click)="moveLevel(li, -1)" [disabled]="li === 0">↑</button>
-                <button type="button" class="ghost-button" (click)="moveLevel(li, 1)" [disabled]="li === levels.length - 1">↓</button>
-                <button type="button" class="ghost-button danger" (click)="removeLevel(li)">Удалить</button>
-              </div>
-            }
-          </div>
+        <details class="level-card">
+          <summary class="level-summary">
+            <span class="level-title">#{{ li + 1 }} ({{ level.id }})</span>
+            <span class="level-stats">
+              {{ AppEmoji.key }} условий: {{ conditionsCount(level) }}
+              {{ AppEmoji.bonusHint }} подсказок: {{ hintsCount(level) }}
+            </span>
+          </summary>
 
-          <!-- Time hints -->
-          <div class="sub-block">
-            <div class="block-head">
-              <h3>Подсказки по времени</h3>
+          <div class="level-body">
+            <div class="level-head">
+              <div class="level-id">
+                <label>ID уровня</label>
+                <input type="text" [(ngModel)]="level.id" [disabled]="!isEditable" />
+              </div>
               @if (isEditable) {
-                <button type="button" class="ghost-button" (click)="addTimeHint(level)">+ Время</button>
+                <div class="level-actions">
+                  <button type="button" class="ghost-button" (click)="moveLevel(li, -1)" [disabled]="li === 0">↑</button>
+                  <button type="button" class="ghost-button" (click)="moveLevel(li, 1)" [disabled]="li === levels.length - 1">↓</button>
+                  <button type="button" class="ghost-button danger" (click)="removeLevel(li)">Удалить</button>
+                </div>
               }
             </div>
 
-            @for (th of level.time_hints; track th; let ti = $index) {
-              <div class="time-hint">
-                <div class="time-row">
-                  <label>Минута</label>
-                  <input class="time-input" type="number" [(ngModel)]="th.time" [disabled]="!isEditable" />
-                  @if (isEditable) {
-                    <button type="button" class="ghost-button" (click)="addHint(th)">+ Подсказка</button>
-                    <button type="button" class="ghost-button danger" (click)="removeTimeHint(level, ti)">Удалить время</button>
-                  }
-                </div>
-                <div class="hints">
-                  @for (h of th.hint; track h; let hi = $index) {
-                    <app-hint-editor
-                      [hint]="h"
-                      [files]="files"
-                      (remove)="removeHint(th, hi)"
-                    ></app-hint-editor>
-                  }
-                </div>
-              </div>
-            }
-          </div>
-
-          <!-- Conditions -->
-          <div class="sub-block">
-            <div class="block-head">
-              <h3>Условия</h3>
-              @if (isEditable) {
-                <button type="button" class="ghost-button" (click)="addCondition(level)">+ Условие</button>
-              }
+            <!-- 1. Default win key -->
+            <div class="sub-block">
+              <label>{{ AppEmoji.key }} Ключ уровня (через пробел; формат SH… или СХ…)</label>
+              <input type="text" [(ngModel)]="level.winKeysText" [disabled]="!isEditable" placeholder="SH123 SH321" />
             </div>
 
-            @for (c of level.conditions; track c; let ci = $index) {
-              <div class="condition">
-                <div class="condition-head">
-                  <select [(ngModel)]="c.type" (ngModelChange)="onConditionTypeChange(c)" [disabled]="!isEditable">
-                    <option [ngValue]="ScenarioConditionType.winKey">Победный ключ (WIN_KEY)</option>
-                    <option [ngValue]="ScenarioConditionType.effectsKey">Ключ с эффектами (EFFECTS_KEY)</option>
-                    <option [ngValue]="ScenarioConditionType.effectsTimer">Таймер с эффектами (EFFECTS_TIMER)</option>
-                  </select>
-                  @if (isEditable) {
-                    <button type="button" class="ghost-button danger" (click)="removeCondition(level, ci)">Удалить</button>
-                  }
-                </div>
+            <!-- 2. Auto-finish timer -->
+            <div class="sub-block">
+              <label>{{ AppEmoji.autoFinish }} Время автозавершения уровня (минуты; пусто — нет)</label>
+              <input class="time-input" type="number" [(ngModel)]="level.autoFinishTime" [disabled]="!isEditable" />
+            </div>
 
-                @if (isKeyCondition(c)) {
-                  <label>Ключи (через пробел; формат SH… или СХ…)</label>
-                  <input type="text" [(ngModel)]="c.keysText" [disabled]="!isEditable" placeholder="SH123 SH321" />
+            <!-- 3. Effect keys -->
+            <div class="sub-block">
+              <div class="block-head">
+                <h3>{{ AppEmoji.key }} Ключи с эффектами</h3>
+                @if (isEditable) {
+                  <button type="button" class="ghost-button" (click)="addKeyCondition(level)">+ Ключ</button>
                 }
-
-                @if (isTimer(c)) {
-                  <label>Время срабатывания (минуты)</label>
-                  <input type="number" [(ngModel)]="c.action_time" [disabled]="!isEditable" />
-                }
-
-                @if (hasEffects(c)) {
-                  <div class="effects">
-                    <h4>Эффекты</h4>
-                    <div class="grid-2">
-                      <div>
-                        <label>Бонус минут (±)</label>
-                        <input type="number" step="any" [(ngModel)]="c.effects.bonus_minutes" [disabled]="!isEditable" />
-                      </div>
-                      <div>
-                        <label>Переход на уровень (id)</label>
-                        <input type="text" [(ngModel)]="c.effects.next_level" [disabled]="!isEditable" placeholder="напр. level-2" />
-                      </div>
-                    </div>
-                    <label class="checkbox">
-                      <input type="checkbox" [(ngModel)]="c.effects.level_up" [disabled]="!isEditable" />
-                      Победа / переход на уровень
-                    </label>
-
-                    <div class="effect-hints">
-                      <div class="block-head">
-                        <span>Бонусные подсказки</span>
-                        @if (isEditable) {
-                          <button type="button" class="ghost-button" (click)="addEffectHint(c)">+ Подсказка</button>
-                        }
-                      </div>
-                      @for (h of c.effects.hints; track h; let hi = $index) {
-                        <app-hint-editor
-                          [hint]="h"
-                          [files]="files"
-                          (remove)="removeEffectHint(c, hi)"
-                        ></app-hint-editor>
-                      }
-                    </div>
+              </div>
+              @for (c of level.keyConditions; track c; let ci = $index) {
+                <div class="condition">
+                  <div class="condition-head">
+                    <input type="text" [(ngModel)]="c.keysText" [disabled]="!isEditable" placeholder="SHBONUS" />
+                    @if (isEditable) {
+                      <button type="button" class="ghost-button danger" (click)="removeKeyCondition(level, ci)">Удалить</button>
+                    }
                   </div>
+                  <app-effects-editor
+                    [effects]="c.effects"
+                    [files]="files"
+                    [gameId]="gameId"
+                    [disabled]="!isEditable"
+                    [allowLevelUp]="true"
+                    [levelIds]="levelIdsExcept(level)"
+                    (fileUploaded)="onHintFileUploaded($event)"
+                  ></app-effects-editor>
+                </div>
+              }
+            </div>
+
+            <!-- 4. Effect timers -->
+            <div class="sub-block">
+              <div class="block-head">
+                <h3>{{ AppEmoji.timer }} Таймеры с эффектами</h3>
+                @if (isEditable) {
+                  <button type="button" class="ghost-button" (click)="addTimerCondition(level)">+ Таймер</button>
                 }
               </div>
-            }
+              @for (c of level.timerConditions; track c; let ci = $index) {
+                <div class="condition">
+                  <div class="condition-head">
+                    <label class="inline-label">Минута</label>
+                    <input class="time-input" type="number" [(ngModel)]="c.action_time" [disabled]="!isEditable" />
+                    @if (isEditable) {
+                      <button type="button" class="ghost-button danger" (click)="removeTimerCondition(level, ci)">Удалить</button>
+                    }
+                  </div>
+                  <app-effects-editor
+                    [effects]="c.effects"
+                    [files]="files"
+                    [gameId]="gameId"
+                    [disabled]="!isEditable"
+                    [allowLevelUp]="false"
+                    (fileUploaded)="onHintFileUploaded($event)"
+                  ></app-effects-editor>
+                </div>
+              }
+            </div>
+
+            <!-- 5. Time hints -->
+            <div class="sub-block">
+              <div class="block-head">
+                <h3>{{ AppEmoji.bonusHint }} Подсказки по времени</h3>
+                @if (isEditable) {
+                  <button type="button" class="ghost-button" (click)="addTimeHint(level)">+ Время</button>
+                }
+              </div>
+
+              @for (th of level.time_hints; track th; let ti = $index) {
+                <div class="time-hint">
+                  <div class="time-row">
+                    <label class="inline-label">Минута</label>
+                    <input class="time-input" type="number" [(ngModel)]="th.time" [disabled]="!isEditable" />
+                    @if (isEditable) {
+                      <app-hint-type-picker (picked)="addHint(th, $event)"></app-hint-type-picker>
+                      <button type="button" class="ghost-button danger" (click)="removeTimeHint(level, ti)">Удалить время</button>
+                    }
+                  </div>
+                  <div class="hints">
+                    @for (h of th.hint; track h; let hi = $index) {
+                      <app-hint-editor
+                        [hint]="h"
+                        [files]="files"
+                        [gameId]="gameId"
+                        [disabled]="!isEditable"
+                        (remove)="removeHint(th, hi)"
+                        (fileUploaded)="onHintFileUploaded($event)"
+                      ></app-hint-editor>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
           </div>
-        </div>
+        </details>
+      }
+    </div>
+
+    <!-- Files -->
+    <div class="block">
+      <h2>{{ AppEmoji.files }} Файлы</h2>
+      <p class="hint-note">Все загруженные файлы игры. Загружать можно и прямо из подсказки.</p>
+      @if (files.length > 0) {
+        <ul class="files-list">
+          @for (f of files; track f.guid) {
+            <li>
+              <div class="file-info">
+                <span class="file-name">{{ fileEmoji(f) }} {{ fileLabel(f) }}</span>
+                @if (fileContentTypeLabel(f)) {
+                  <span class="file-type">{{ fileContentTypeLabel(f) }}</span>
+                }
+              </div>
+              @switch (filePreviewKind(f)) {
+                @case ("image") {
+                  <img class="file-preview" [src]="fileUrl(f)" alt="превью" loading="lazy" />
+                }
+                @case ("video") {
+                  <video class="file-preview" [src]="fileUrl(f)" controls preload="none"></video>
+                }
+                @case ("audio") {
+                  <audio class="file-preview-audio" [src]="fileUrl(f)" controls preload="none"></audio>
+                }
+              }
+            </li>
+          }
+        </ul>
+      }
+      @if (isEditable) {
+        <label class="upload-button" [class.busy]="isUploading">
+          {{ AppEmoji.upload }} {{ isUploading ? "Загрузка..." : "Загрузить файл" }}
+          <input type="file" hidden (change)="onFileSelected($event)" [disabled]="isUploading" />
+        </label>
       }
     </div>
 

--- a/src/app/constructor/game-editor.component.html
+++ b/src/app/constructor/game-editor.component.html
@@ -185,12 +185,12 @@
               @for (th of level.time_hints; track th; let ti = $index) {
                 <div class="time-hint">
                   <div class="time-row">
-                    <label class="inline-label">Минута</label>
+                    <span class="inline-label">подсказка в</span>
                     <input class="time-input" type="number" min="0" [(ngModel)]="th.time" [disabled]="!isEditable"
                            [class.invalid]="th.time < 0" />
+                    <span class="inline-label">мин.</span>
                     @if (isEditable) {
-                      <app-hint-type-picker (picked)="addHint(th, $event)"></app-hint-type-picker>
-                      <button type="button" class="ghost-button danger" (click)="removeTimeHint(level, ti)">Удалить время</button>
+                      <button type="button" class="ghost-button icon danger" (click)="removeTimeHint(level, ti)" title="Удалить подсказку">{{ AppEmoji.remove }}</button>
                     }
                   </div>
                   @if (th.time < 0) {
@@ -208,6 +208,9 @@
                       ></app-hint-editor>
                     }
                   </div>
+                  @if (isEditable) {
+                    <app-hint-type-picker label="+ контент" (picked)="addHint(th, $event)"></app-hint-type-picker>
+                  }
                 </div>
               }
             </div>

--- a/src/app/constructor/game-editor.component.html
+++ b/src/app/constructor/game-editor.component.html
@@ -1,0 +1,230 @@
+<section class="editor-page">
+  <a routerLink="/games/constructor" class="back-link">← К списку игр</a>
+
+  @if (isLoading && !game) {
+    <div class="loading-state" aria-live="polite">
+      <span class="loading-spinner"></span>
+      Загрузка игры...
+    </div>
+  }
+
+  @if (game) {
+    <div class="editor-head">
+      <h1>Редактирование игры</h1>
+      <span class="status-badge">{{ statusLabel(status) }}</span>
+    </div>
+
+    @if (!isEditable) {
+      <p class="warn">Игра в статусе «{{ statusLabel(status) }}» — сценарий заморожен и недоступен для редактирования.</p>
+    }
+
+    <!-- Game name -->
+    <div class="block">
+      <label for="gameName">Название игры</label>
+      <input id="gameName" type="text" [(ngModel)]="name" [disabled]="!isEditable" />
+    </div>
+
+    <!-- Files -->
+    <div class="block">
+      <h2>Файлы</h2>
+      <p class="hint-note">Загрузите медиа заранее, затем выбирайте их в подсказках.</p>
+      @if (files.length > 0) {
+        <ul class="files-list">
+          @for (f of files; track f.guid) {
+            <li>
+              <span class="file-name">{{ fileLabel(f) }}</span>
+              <span class="file-guid">{{ f.guid }}</span>
+            </li>
+          }
+        </ul>
+      }
+      @if (isEditable) {
+        <label class="upload-control">
+          <input type="file" (change)="onFileSelected($event)" [disabled]="isUploading" />
+        </label>
+        @if (isUploading) {
+          <span class="hint-note">Загрузка файла...</span>
+        }
+      }
+    </div>
+
+    <!-- Levels -->
+    <div class="block">
+      <div class="block-head">
+        <h2>Уровни</h2>
+        @if (isEditable) {
+          <button type="button" class="primary" (click)="addLevel()">+ Уровень</button>
+        }
+      </div>
+
+      @for (level of levels; track level; let li = $index) {
+        <div class="level-card">
+          <div class="level-head">
+            <div class="level-id">
+              <label>ID уровня #{{ li + 1 }}</label>
+              <input type="text" [(ngModel)]="level.id" [disabled]="!isEditable" />
+            </div>
+            @if (isEditable) {
+              <div class="level-actions">
+                <button type="button" class="ghost-button" (click)="moveLevel(li, -1)" [disabled]="li === 0">↑</button>
+                <button type="button" class="ghost-button" (click)="moveLevel(li, 1)" [disabled]="li === levels.length - 1">↓</button>
+                <button type="button" class="ghost-button danger" (click)="removeLevel(li)">Удалить</button>
+              </div>
+            }
+          </div>
+
+          <!-- Time hints -->
+          <div class="sub-block">
+            <div class="block-head">
+              <h3>Подсказки по времени</h3>
+              @if (isEditable) {
+                <button type="button" class="ghost-button" (click)="addTimeHint(level)">+ Время</button>
+              }
+            </div>
+
+            @for (th of level.time_hints; track th; let ti = $index) {
+              <div class="time-hint">
+                <div class="time-row">
+                  <label>Минута</label>
+                  <input class="time-input" type="number" [(ngModel)]="th.time" [disabled]="!isEditable" />
+                  @if (isEditable) {
+                    <button type="button" class="ghost-button" (click)="addHint(th)">+ Подсказка</button>
+                    <button type="button" class="ghost-button danger" (click)="removeTimeHint(level, ti)">Удалить время</button>
+                  }
+                </div>
+                <div class="hints">
+                  @for (h of th.hint; track h; let hi = $index) {
+                    <app-hint-editor
+                      [hint]="h"
+                      [files]="files"
+                      (remove)="removeHint(th, hi)"
+                    ></app-hint-editor>
+                  }
+                </div>
+              </div>
+            }
+          </div>
+
+          <!-- Conditions -->
+          <div class="sub-block">
+            <div class="block-head">
+              <h3>Условия</h3>
+              @if (isEditable) {
+                <button type="button" class="ghost-button" (click)="addCondition(level)">+ Условие</button>
+              }
+            </div>
+
+            @for (c of level.conditions; track c; let ci = $index) {
+              <div class="condition">
+                <div class="condition-head">
+                  <select [(ngModel)]="c.type" (ngModelChange)="onConditionTypeChange(c)" [disabled]="!isEditable">
+                    <option [ngValue]="ScenarioConditionType.winKey">Победный ключ (WIN_KEY)</option>
+                    <option [ngValue]="ScenarioConditionType.effectsKey">Ключ с эффектами (EFFECTS_KEY)</option>
+                    <option [ngValue]="ScenarioConditionType.effectsTimer">Таймер с эффектами (EFFECTS_TIMER)</option>
+                  </select>
+                  @if (isEditable) {
+                    <button type="button" class="ghost-button danger" (click)="removeCondition(level, ci)">Удалить</button>
+                  }
+                </div>
+
+                @if (isKeyCondition(c)) {
+                  <label>Ключи (через пробел; формат SH… или СХ…)</label>
+                  <input type="text" [(ngModel)]="c.keysText" [disabled]="!isEditable" placeholder="SH123 SH321" />
+                }
+
+                @if (isTimer(c)) {
+                  <label>Время срабатывания (минуты)</label>
+                  <input type="number" [(ngModel)]="c.action_time" [disabled]="!isEditable" />
+                }
+
+                @if (hasEffects(c)) {
+                  <div class="effects">
+                    <h4>Эффекты</h4>
+                    <div class="grid-2">
+                      <div>
+                        <label>Бонус минут (±)</label>
+                        <input type="number" step="any" [(ngModel)]="c.effects.bonus_minutes" [disabled]="!isEditable" />
+                      </div>
+                      <div>
+                        <label>Переход на уровень (id)</label>
+                        <input type="text" [(ngModel)]="c.effects.next_level" [disabled]="!isEditable" placeholder="напр. level-2" />
+                      </div>
+                    </div>
+                    <label class="checkbox">
+                      <input type="checkbox" [(ngModel)]="c.effects.level_up" [disabled]="!isEditable" />
+                      Победа / переход на уровень
+                    </label>
+
+                    <div class="effect-hints">
+                      <div class="block-head">
+                        <span>Бонусные подсказки</span>
+                        @if (isEditable) {
+                          <button type="button" class="ghost-button" (click)="addEffectHint(c)">+ Подсказка</button>
+                        }
+                      </div>
+                      @for (h of c.effects.hints; track h; let hi = $index) {
+                        <app-hint-editor
+                          [hint]="h"
+                          [files]="files"
+                          (remove)="removeEffectHint(c, hi)"
+                        ></app-hint-editor>
+                      }
+                    </div>
+                  </div>
+                }
+              </div>
+            }
+          </div>
+        </div>
+      }
+    </div>
+
+    <!-- Validation errors -->
+    @if (validationErrors.length > 0) {
+      <div class="block errors">
+        <h3>Ошибки проверки</h3>
+        <ul>
+          @for (err of validationErrors; track err) {
+            <li>{{ err }}</li>
+          }
+        </ul>
+      </div>
+    }
+
+    <!-- Save -->
+    @if (isEditable) {
+      <div class="actions-bar">
+        <button type="button" class="primary" (click)="save()" [disabled]="isSaving">
+          {{ isSaving ? "Сохраняем..." : "Сохранить сценарий" }}
+        </button>
+      </div>
+    }
+
+    <!-- Start time -->
+    <div class="block">
+      <h2>Планируемый старт</h2>
+      <div class="start-row">
+        <input type="datetime-local" [(ngModel)]="startAtLocal" [disabled]="!isEditable" />
+        <button type="button" class="primary" (click)="saveStartAt()" [disabled]="!isEditable">Сохранить</button>
+        <button type="button" class="ghost-button" (click)="clearStartAt()" [disabled]="!isEditable">Отменить старт</button>
+      </div>
+    </div>
+
+    <!-- Status -->
+    <div class="block">
+      <h2>Статус игры</h2>
+      <p>Текущий статус: <strong>{{ statusLabel(status) }}</strong></p>
+      <div class="status-actions">
+        @if (canOpenWaivers) {
+          <button type="button" class="primary" (click)="changeStatus('getting_waivers')">Открыть сбор вейверов</button>
+        }
+        @if (canComplete) {
+          <button type="button" class="primary" (click)="changeStatus('complete')">Опубликовать игру</button>
+        }
+        @if (!canOpenWaivers && !canComplete) {
+          <p class="hint-note">Для текущего статуса нет доступных переходов.</p>
+        }
+      </div>
+    </div>
+  }
+</section>

--- a/src/app/constructor/game-editor.component.html
+++ b/src/app/constructor/game-editor.component.html
@@ -33,14 +33,26 @@
         }
       </div>
 
+      <div cdkDropList (cdkDropListDropped)="onLevelDrop($event)">
       @for (level of levels; track level; let li = $index) {
-        <details class="level-card">
+        <details class="level-card" cdkDrag [cdkDragDisabled]="!isEditable">
           <summary class="level-summary">
+            @if (isEditable) {
+              <span class="drag-handle" cdkDragHandle title="Перетащите, чтобы изменить порядок"
+                    (click)="$event.preventDefault(); $event.stopPropagation()">{{ AppEmoji.reorder }}</span>
+            }
             <span class="level-title">#{{ li + 1 }} ({{ level.id }})</span>
             <span class="level-stats">
               {{ AppEmoji.key }} условий: {{ conditionsCount(level) }}
               {{ AppEmoji.bonusHint }} подсказок: {{ hintsCount(level) }}
             </span>
+            @if (isEditable) {
+              <span class="level-actions">
+                <button type="button" class="ghost-button icon" (click)="moveLevel(li, -1); $event.preventDefault(); $event.stopPropagation()" [disabled]="li === 0" title="Вверх">↑</button>
+                <button type="button" class="ghost-button icon" (click)="moveLevel(li, 1); $event.preventDefault(); $event.stopPropagation()" [disabled]="li === levels.length - 1" title="Вниз">↓</button>
+                <button type="button" class="ghost-button icon danger" (click)="removeLevel(li); $event.preventDefault(); $event.stopPropagation()" title="Удалить уровень">{{ AppEmoji.remove }}</button>
+              </span>
+            }
           </summary>
 
           <div class="level-body">
@@ -49,13 +61,6 @@
                 <label>ID уровня</label>
                 <input type="text" [(ngModel)]="level.id" [disabled]="!isEditable" />
               </div>
-              @if (isEditable) {
-                <div class="level-actions">
-                  <button type="button" class="ghost-button" (click)="moveLevel(li, -1)" [disabled]="li === 0">↑</button>
-                  <button type="button" class="ghost-button" (click)="moveLevel(li, 1)" [disabled]="li === levels.length - 1">↓</button>
-                  <button type="button" class="ghost-button danger" (click)="removeLevel(li)">Удалить</button>
-                </div>
-              }
             </div>
 
             <!-- 1. Default win key -->
@@ -92,7 +97,7 @@
                     [gameId]="gameId"
                     [disabled]="!isEditable"
                     [allowLevelUp]="true"
-                    [levelIds]="levelIdsExcept(level)"
+                    [levelIds]="allLevelIds()"
                     (fileUploaded)="onHintFileUploaded($event)"
                   ></app-effects-editor>
                 </div>
@@ -165,6 +170,7 @@
           </div>
         </details>
       }
+      </div>
     </div>
 
     <!-- Files -->
@@ -183,7 +189,7 @@
               </div>
               @switch (filePreviewKind(f)) {
                 @case ("image") {
-                  <img class="file-preview" [src]="fileUrl(f)" alt="превью" loading="lazy" />
+                  <app-image-lightbox [src]="fileUrl(f)"></app-image-lightbox>
                 }
                 @case ("video") {
                   <video class="file-preview" [src]="fileUrl(f)" controls preload="none"></video>

--- a/src/app/constructor/game-editor.component.html
+++ b/src/app/constructor/game-editor.component.html
@@ -13,7 +13,7 @@
       <h1>Редактирование игры «{{ name }}»</h1>
       <span class="status-badge">{{ statusLabel(status) }}</span>
       @if (canOpenWaivers) {
-        <button type="button" class="primary" (click)="changeStatus('getting_waivers')">Открыть сбор вейверов</button>
+        <button type="button" class="primary" (click)="changeStatus('getting_waivers')">Начать сбор вейверов</button>
       }
       @if (canComplete) {
         <button type="button" class="primary" (click)="changeStatus('complete')">Опубликовать игру</button>
@@ -51,9 +51,10 @@
 
       <div cdkDropList (cdkDropListDropped)="onLevelDrop($event)">
       @for (level of levels; track level; let li = $index) {
-        <details class="level-card" cdkDrag [cdkDragDisabled]="!isEditable">
+        <details class="level-card" cdkDrag [cdkDragDisabled]="!isEditable || anyLevelExpanded()"
+                 [open]="level.expanded" (toggle)="onLevelToggle(level, $event)">
           <summary class="level-summary">
-            @if (isEditable) {
+            @if (isEditable && !anyLevelExpanded()) {
               <span class="drag-handle" cdkDragHandle title="Перетащите, чтобы изменить порядок"
                     (click)="$event.preventDefault(); $event.stopPropagation()"></span>
             }
@@ -88,7 +89,7 @@
               <label>{{ AppEmoji.key }} Ключ уровня (несколько — через пробел)</label>
               <input type="text" [ngModel]="level.winKeysText"
                      (ngModelChange)="level.winKeysText = upperKeys($event)"
-                     [disabled]="!isEditable" placeholder="SH123 SH321"
+                     [disabled]="!isEditable" placeholder="например: SH123 SH321"
                      [class.invalid]="!areKeysOk(level.winKeysText)" />
               @if (!areKeysOk(level.winKeysText)) {
                 <span class="field-error">Ключ начинается с SH или СХ, дальше только заглавные буквы и цифры (например SH123, СХКЛЮЧ).</span>
@@ -118,7 +119,7 @@
                   <div class="condition-head">
                     <input type="text" [ngModel]="c.keysText"
                            (ngModelChange)="c.keysText = upperKeys($event)"
-                           [disabled]="!isEditable" placeholder="SHBONUS"
+                           [disabled]="!isEditable" placeholder="например: SHBONUS"
                            [class.invalid]="!areKeysOk(c.keysText)" />
                     @if (isEditable) {
                       <button type="button" class="ghost-button danger" (click)="removeKeyCondition(level, ci)">Удалить</button>
@@ -131,6 +132,7 @@
                     [effects]="c.effects"
                     [files]="files"
                     [gameId]="gameId"
+                    [objectUrls]="objectUrls"
                     [disabled]="!isEditable"
                     [allowLevelUp]="true"
                     [levelIds]="allLevelIds()"
@@ -165,6 +167,7 @@
                     [effects]="c.effects"
                     [files]="files"
                     [gameId]="gameId"
+                    [objectUrls]="objectUrls"
                     [disabled]="!isEditable"
                     [allowLevelUp]="false"
                     (fileUploaded)="onHintFileUploaded($event)"
@@ -202,6 +205,7 @@
                         [hint]="h"
                         [files]="files"
                         [gameId]="gameId"
+                        [objectUrls]="objectUrls"
                         [disabled]="!isEditable"
                         (remove)="removeHint(th, hi)"
                         (fileUploaded)="onHintFileUploaded($event)"

--- a/src/app/constructor/game-editor.component.html
+++ b/src/app/constructor/game-editor.component.html
@@ -10,13 +10,29 @@
 
   @if (game) {
     <div class="editor-head">
-      <h1>Редактирование игры</h1>
+      <h1>Редактирование игры «{{ name }}»</h1>
       <span class="status-badge">{{ statusLabel(status) }}</span>
+      @if (canOpenWaivers) {
+        <button type="button" class="primary" (click)="changeStatus('getting_waivers')">Открыть сбор вейверов</button>
+      }
+      @if (canComplete) {
+        <button type="button" class="primary" (click)="changeStatus('complete')">Опубликовать игру</button>
+      }
     </div>
 
     @if (!isEditable) {
       <p class="warn">Игра в статусе «{{ statusLabel(status) }}» — сценарий заморожен и недоступен для редактирования.</p>
     }
+
+    <!-- Planned start -->
+    <div class="block">
+      <h2>Планируемый старт</h2>
+      <div class="start-row">
+        <input type="datetime-local" [(ngModel)]="startAtLocal" [disabled]="!isEditable" />
+        <button type="button" class="primary" (click)="saveStartAt()" [disabled]="!isEditable">Сохранить</button>
+        <button type="button" class="ghost-button" (click)="clearStartAt()" [disabled]="!isEditable">Отменить старт</button>
+      </div>
+    </div>
 
     <!-- Game name -->
     <div class="block">
@@ -39,7 +55,7 @@
           <summary class="level-summary">
             @if (isEditable) {
               <span class="drag-handle" cdkDragHandle title="Перетащите, чтобы изменить порядок"
-                    (click)="$event.preventDefault(); $event.stopPropagation()">{{ AppEmoji.reorder }}</span>
+                    (click)="$event.preventDefault(); $event.stopPropagation()"></span>
             }
             <span class="level-title">#{{ li + 1 }} ({{ level.id }})</span>
             <span class="level-stats">
@@ -59,20 +75,34 @@
             <div class="level-head">
               <div class="level-id">
                 <label>ID уровня</label>
-                <input type="text" [(ngModel)]="level.id" [disabled]="!isEditable" />
+                <input type="text" [(ngModel)]="level.id" [disabled]="!isEditable"
+                       [class.invalid]="!isLevelIdOk(level.id)" />
+                @if (!isLevelIdOk(level.id)) {
+                  <span class="field-error">Только латинские буквы, цифры, «_» и «-», без пробелов.</span>
+                }
               </div>
             </div>
 
             <!-- 1. Default win key -->
             <div class="sub-block">
-              <label>{{ AppEmoji.key }} Ключ уровня (через пробел; формат SH… или СХ…)</label>
-              <input type="text" [(ngModel)]="level.winKeysText" [disabled]="!isEditable" placeholder="SH123 SH321" />
+              <label>{{ AppEmoji.key }} Ключ уровня (несколько — через пробел)</label>
+              <input type="text" [ngModel]="level.winKeysText"
+                     (ngModelChange)="level.winKeysText = upperKeys($event)"
+                     [disabled]="!isEditable" placeholder="SH123 SH321"
+                     [class.invalid]="!areKeysOk(level.winKeysText)" />
+              @if (!areKeysOk(level.winKeysText)) {
+                <span class="field-error">Ключ начинается с SH или СХ, дальше только заглавные буквы и цифры (например SH123, СХКЛЮЧ).</span>
+              }
             </div>
 
             <!-- 2. Auto-finish timer -->
             <div class="sub-block">
               <label>{{ AppEmoji.autoFinish }} Время автозавершения уровня (минуты; пусто — нет)</label>
-              <input class="time-input" type="number" [(ngModel)]="level.autoFinishTime" [disabled]="!isEditable" />
+              <input class="time-input" type="number" min="0" [(ngModel)]="level.autoFinishTime" [disabled]="!isEditable"
+                     [class.invalid]="level.autoFinishTime != null && level.autoFinishTime < 0" />
+              @if (level.autoFinishTime != null && level.autoFinishTime < 0) {
+                <span class="field-error">Время не может быть отрицательным.</span>
+              }
             </div>
 
             <!-- 3. Effect keys -->
@@ -86,11 +116,17 @@
               @for (c of level.keyConditions; track c; let ci = $index) {
                 <div class="condition">
                   <div class="condition-head">
-                    <input type="text" [(ngModel)]="c.keysText" [disabled]="!isEditable" placeholder="SHBONUS" />
+                    <input type="text" [ngModel]="c.keysText"
+                           (ngModelChange)="c.keysText = upperKeys($event)"
+                           [disabled]="!isEditable" placeholder="SHBONUS"
+                           [class.invalid]="!areKeysOk(c.keysText)" />
                     @if (isEditable) {
                       <button type="button" class="ghost-button danger" (click)="removeKeyCondition(level, ci)">Удалить</button>
                     }
                   </div>
+                  @if (!areKeysOk(c.keysText)) {
+                    <span class="field-error">Ключ начинается с SH или СХ, дальше только заглавные буквы и цифры (например SH123, СХКЛЮЧ).</span>
+                  }
                   <app-effects-editor
                     [effects]="c.effects"
                     [files]="files"
@@ -116,11 +152,15 @@
                 <div class="condition">
                   <div class="condition-head">
                     <label class="inline-label">Минута</label>
-                    <input class="time-input" type="number" [(ngModel)]="c.action_time" [disabled]="!isEditable" />
+                    <input class="time-input" type="number" min="0" [(ngModel)]="c.action_time" [disabled]="!isEditable"
+                           [class.invalid]="c.action_time != null && c.action_time < 0" />
                     @if (isEditable) {
                       <button type="button" class="ghost-button danger" (click)="removeTimerCondition(level, ci)">Удалить</button>
                     }
                   </div>
+                  @if (c.action_time != null && c.action_time < 0) {
+                    <span class="field-error">Время не может быть отрицательным.</span>
+                  }
                   <app-effects-editor
                     [effects]="c.effects"
                     [files]="files"
@@ -146,12 +186,16 @@
                 <div class="time-hint">
                   <div class="time-row">
                     <label class="inline-label">Минута</label>
-                    <input class="time-input" type="number" [(ngModel)]="th.time" [disabled]="!isEditable" />
+                    <input class="time-input" type="number" min="0" [(ngModel)]="th.time" [disabled]="!isEditable"
+                           [class.invalid]="th.time < 0" />
                     @if (isEditable) {
                       <app-hint-type-picker (picked)="addHint(th, $event)"></app-hint-type-picker>
                       <button type="button" class="ghost-button danger" (click)="removeTimeHint(level, ti)">Удалить время</button>
                     }
                   </div>
+                  @if (th.time < 0) {
+                    <span class="field-error">Время не может быть отрицательным.</span>
+                  }
                   <div class="hints">
                     @for (h of th.hint; track h; let hi = $index) {
                       <app-hint-editor
@@ -230,32 +274,5 @@
         </button>
       </div>
     }
-
-    <!-- Start time -->
-    <div class="block">
-      <h2>Планируемый старт</h2>
-      <div class="start-row">
-        <input type="datetime-local" [(ngModel)]="startAtLocal" [disabled]="!isEditable" />
-        <button type="button" class="primary" (click)="saveStartAt()" [disabled]="!isEditable">Сохранить</button>
-        <button type="button" class="ghost-button" (click)="clearStartAt()" [disabled]="!isEditable">Отменить старт</button>
-      </div>
-    </div>
-
-    <!-- Status -->
-    <div class="block">
-      <h2>Статус игры</h2>
-      <p>Текущий статус: <strong>{{ statusLabel(status) }}</strong></p>
-      <div class="status-actions">
-        @if (canOpenWaivers) {
-          <button type="button" class="primary" (click)="changeStatus('getting_waivers')">Открыть сбор вейверов</button>
-        }
-        @if (canComplete) {
-          <button type="button" class="primary" (click)="changeStatus('complete')">Опубликовать игру</button>
-        }
-        @if (!canOpenWaivers && !canComplete) {
-          <p class="hint-note">Для текущего статуса нет доступных переходов.</p>
-        }
-      </div>
-    </div>
   }
 </section>

--- a/src/app/constructor/game-editor.component.html
+++ b/src/app/constructor/game-editor.component.html
@@ -54,11 +54,13 @@
         <details class="level-card" cdkDrag [cdkDragDisabled]="!isEditable || anyLevelExpanded()"
                  [open]="level.expanded" (toggle)="onLevelToggle(level, $event)">
           <summary class="level-summary">
-            @if (isEditable && !anyLevelExpanded()) {
-              <span class="drag-handle" cdkDragHandle title="Перетащите, чтобы изменить порядок"
-                    (click)="$event.preventDefault(); $event.stopPropagation()"></span>
-            }
-            <span class="level-title">#{{ li + 1 }} ({{ level.id }})</span>
+            <span class="level-caption">
+              @if (isEditable && !anyLevelExpanded()) {
+                <span class="drag-handle" cdkDragHandle title="Перетащите, чтобы изменить порядок"
+                      (click)="$event.preventDefault(); $event.stopPropagation()"></span>
+              }
+              <span class="level-title">#{{ li + 1 }} ({{ level.id }})</span>
+            </span>
             <span class="level-stats">
               {{ AppEmoji.key }} условий: {{ conditionsCount(level) }}
               {{ AppEmoji.bonusHint }} подсказок: {{ hintsCount(level) }}

--- a/src/app/constructor/game-editor.component.scss
+++ b/src/app/constructor/game-editor.component.scss
@@ -156,9 +156,15 @@ input.invalid {
   font-weight: 600;
 }
 
-.level-title {
+.level-caption {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
   flex: 1 1 auto;
-  min-width: 6rem;
+  min-width: 0;
+}
+
+.level-title {
   overflow-wrap: anywhere;
 }
 
@@ -373,16 +379,12 @@ input.time-input {
 }
 
 @media (max-width: 640px) {
-  .level-title {
+  .level-caption {
     flex-basis: 100%;
   }
 
   .start-row input[type="datetime-local"] {
     flex: 1 1 100%;
-  }
-
-  .actions-bar {
-    justify-content: stretch;
   }
 
   .actions-bar .primary {

--- a/src/app/constructor/game-editor.component.scss
+++ b/src/app/constructor/game-editor.component.scss
@@ -83,6 +83,18 @@ select {
   width: 100%;
 }
 
+input.invalid {
+  border-color: #c62828;
+  background: color-mix(in srgb, var(--app-surface) 90%, #c62828);
+}
+
+.field-error {
+  display: block;
+  margin-top: 0.25rem;
+  font-size: 0.8rem;
+  color: #c62828;
+}
+
 .primary {
   @include cm.button-base();
   background: var(--app-accent);
@@ -140,7 +152,14 @@ select {
   cursor: grab;
   font-size: 1rem;
   line-height: 1;
-  opacity: 0.7;
+  opacity: 0.6;
+  width: 1rem;
+  text-align: center;
+  flex: none;
+}
+
+.drag-handle::before {
+  content: "⠿";
 }
 
 .drag-handle:active {

--- a/src/app/constructor/game-editor.component.scss
+++ b/src/app/constructor/game-editor.component.scss
@@ -1,0 +1,274 @@
+@use "../../styles/component-mixins" as cm;
+
+.editor-page {
+  max-width: 880px;
+  margin: 0 auto;
+}
+
+.back-link {
+  display: inline-block;
+  margin-bottom: 0.75rem;
+  color: var(--app-accent);
+  text-decoration: none;
+}
+
+.editor-head {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+h1 {
+  margin: 0;
+  color: inherit;
+}
+
+h2 {
+  font-size: 1.1rem;
+  margin: 0 0 0.5rem;
+  color: inherit;
+}
+
+h3 {
+  font-size: 1rem;
+  margin: 0;
+  color: inherit;
+}
+
+h4 {
+  font-size: 0.95rem;
+  margin: 0 0 0.4rem;
+  color: inherit;
+}
+
+.status-badge {
+  font-size: 0.85rem;
+  color: var(--app-muted-text);
+  background: color-mix(in srgb, var(--app-surface) 70%, var(--app-accent));
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+}
+
+.warn {
+  color: #b26a00;
+  background: color-mix(in srgb, var(--app-surface) 80%, #f0ad4e);
+  padding: 0.6rem 0.8rem;
+  border-radius: 10px;
+}
+
+.block {
+  @include cm.surface-card(14px, 1rem);
+  margin: 1rem 0;
+}
+
+.block-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+label {
+  font-size: 0.85rem;
+  color: var(--app-muted-text);
+  display: block;
+  margin-bottom: 0.2rem;
+}
+
+label.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: inherit;
+  margin: 0.4rem 0;
+}
+
+input[type="text"],
+input[type="number"],
+input[type="datetime-local"],
+select {
+  @include cm.input-control();
+  width: 100%;
+}
+
+.primary {
+  @include cm.button-base();
+  background: var(--app-accent);
+  color: var(--app-accent-contrast);
+  white-space: nowrap;
+}
+
+.primary:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.ghost-button {
+  @include cm.button-base();
+  background: transparent;
+  border: 1px solid var(--app-border);
+  color: inherit;
+  white-space: nowrap;
+}
+
+.ghost-button.danger {
+  color: #c62828;
+  border-color: #c62828;
+}
+
+.ghost-button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.level-card {
+  border: 1px solid var(--app-border);
+  border-radius: 12px;
+  padding: 0.85rem;
+  margin-bottom: 1rem;
+  background: color-mix(in srgb, var(--app-surface) 96%, transparent);
+}
+
+.level-head {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.level-id {
+  flex: 1;
+}
+
+.level-actions {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.sub-block {
+  margin-top: 0.85rem;
+  padding-top: 0.85rem;
+  border-top: 1px dashed var(--app-border);
+}
+
+.time-hint {
+  border: 1px solid var(--app-border);
+  border-radius: 10px;
+  padding: 0.6rem;
+  margin-bottom: 0.6rem;
+}
+
+.time-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.time-input {
+  width: 6rem;
+}
+
+.hints,
+.effect-hints {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.condition {
+  border: 1px solid var(--app-border);
+  border-radius: 10px;
+  padding: 0.6rem;
+  margin-bottom: 0.6rem;
+}
+
+.condition-head {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.effects {
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  border-top: 1px dashed var(--app-border);
+}
+
+.effect-hints {
+  margin-top: 0.5rem;
+}
+
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.files-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.6rem;
+  display: grid;
+  gap: 0.3rem;
+}
+
+.files-list li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  padding: 0.3rem 0.5rem;
+  border: 1px solid var(--app-border);
+  border-radius: 8px;
+}
+
+.file-guid {
+  color: var(--app-muted-text);
+  font-family: monospace;
+  font-size: 0.75rem;
+}
+
+.hint-note {
+  font-size: 0.85rem;
+  color: var(--app-muted-text);
+  margin: 0.3rem 0;
+}
+
+.errors {
+  border-color: #c62828;
+}
+
+.errors ul {
+  margin: 0;
+  padding-left: 1.2rem;
+}
+
+.errors li {
+  color: #c62828;
+  font-size: 0.9rem;
+}
+
+.actions-bar {
+  position: sticky;
+  bottom: 0;
+  display: flex;
+  justify-content: flex-end;
+  padding: 0.75rem 0;
+}
+
+.actions-bar .primary {
+  font-size: 1rem;
+  padding: 0.7rem 1.4rem;
+}
+
+.start-row,
+.status-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  align-items: center;
+}

--- a/src/app/constructor/game-editor.component.scss
+++ b/src/app/constructor/game-editor.component.scss
@@ -16,11 +16,21 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  flex-wrap: wrap;
 }
 
 h1 {
   margin: 0;
   color: inherit;
+  font-size: 1.6rem;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 640px) {
+  h1 {
+    flex: 1 1 100%;
+    font-size: 1.3rem;
+  }
 }
 
 h2 {
@@ -41,6 +51,7 @@ h3 {
   background: color-mix(in srgb, var(--app-surface) 70%, var(--app-accent));
   padding: 0.2rem 0.6rem;
   border-radius: 999px;
+  white-space: nowrap;
 }
 
 .warn {
@@ -73,6 +84,8 @@ label {
 .inline-label {
   display: inline;
   margin: 0;
+  white-space: nowrap;
+  flex: none;
 }
 
 input[type="text"],
@@ -85,7 +98,6 @@ select {
 
 input.invalid {
   border-color: #c62828;
-  background: color-mix(in srgb, var(--app-surface) 90%, #c62828);
 }
 
 .field-error {
@@ -145,7 +157,9 @@ input.invalid {
 }
 
 .level-title {
-  flex: 1;
+  flex: 1 1 auto;
+  min-width: 6rem;
+  overflow-wrap: anywhere;
 }
 
 .drag-handle {
@@ -171,20 +185,6 @@ input.invalid {
   line-height: 1;
 }
 
-// CDK drag-drop
-.cdk-drag-preview {
-  @include cm.surface-card(12px, 0);
-  box-shadow: 0 12px 32px rgba(16, 24, 40, 0.25);
-}
-
-.cdk-drag-placeholder {
-  opacity: 0.4;
-}
-
-.cdk-drag-animating {
-  transition: transform 0.2s cubic-bezier(0, 0, 0.2, 1);
-}
-
 .level-summary::marker {
   content: "";
 }
@@ -206,17 +206,6 @@ input.invalid {
 
 .level-body {
   padding: 0.85rem;
-}
-
-.level-head {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 0.5rem;
-}
-
-.level-id {
-  flex: 1;
 }
 
 .level-actions {
@@ -245,8 +234,9 @@ input.invalid {
   flex-wrap: wrap;
 }
 
-.time-input {
+input.time-input {
   width: 6rem;
+  max-width: 100%;
 }
 
 .hints {
@@ -267,10 +257,12 @@ input.invalid {
   gap: 0.5rem;
   align-items: center;
   margin-bottom: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .condition-head input[type="text"] {
   flex: 1;
+  min-width: 8rem;
 }
 
 // Files
@@ -373,10 +365,27 @@ input.invalid {
   padding: 0.7rem 1.4rem;
 }
 
-.start-row,
-.status-actions {
+.start-row {
   display: flex;
   gap: 0.5rem;
   flex-wrap: wrap;
   align-items: center;
+}
+
+@media (max-width: 640px) {
+  .level-title {
+    flex-basis: 100%;
+  }
+
+  .start-row input[type="datetime-local"] {
+    flex: 1 1 100%;
+  }
+
+  .actions-bar {
+    justify-content: stretch;
+  }
+
+  .actions-bar .primary {
+    flex: 1;
+  }
 }

--- a/src/app/constructor/game-editor.component.scss
+++ b/src/app/constructor/game-editor.component.scss
@@ -35,12 +35,6 @@ h3 {
   color: inherit;
 }
 
-h4 {
-  font-size: 0.95rem;
-  margin: 0 0 0.4rem;
-  color: inherit;
-}
-
 .status-badge {
   font-size: 0.85rem;
   color: var(--app-muted-text);
@@ -76,12 +70,9 @@ label {
   margin-bottom: 0.2rem;
 }
 
-label.checkbox {
-  display: flex;
-  align-items: center;
-  gap: 0.4rem;
-  color: inherit;
-  margin: 0.4rem 0;
+.inline-label {
+  display: inline;
+  margin: 0;
 }
 
 input[type="text"],
@@ -122,12 +113,47 @@ select {
   cursor: not-allowed;
 }
 
+// Collapsible level card
 .level-card {
   border: 1px solid var(--app-border);
   border-radius: 12px;
-  padding: 0.85rem;
   margin-bottom: 1rem;
   background: color-mix(in srgb, var(--app-surface) 96%, transparent);
+}
+
+.level-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  padding: 0.7rem 0.85rem;
+  cursor: pointer;
+  user-select: none;
+  font-weight: 600;
+}
+
+.level-summary::marker {
+  content: "";
+}
+
+.level-summary::-webkit-details-marker {
+  display: none;
+}
+
+.level-card[open] .level-summary {
+  border-bottom: 1px dashed var(--app-border);
+}
+
+.level-stats {
+  font-weight: 400;
+  font-size: 0.85rem;
+  color: var(--app-muted-text);
+  white-space: nowrap;
+}
+
+.level-body {
+  padding: 0.85rem;
 }
 
 .level-head {
@@ -161,7 +187,7 @@ select {
 
 .time-row {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: 0.5rem;
   margin-bottom: 0.5rem;
   flex-wrap: wrap;
@@ -171,8 +197,7 @@ select {
   width: 6rem;
 }
 
-.hints,
-.effect-hints {
+.hints {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
@@ -192,44 +217,75 @@ select {
   margin-bottom: 0.5rem;
 }
 
-.effects {
-  margin-top: 0.5rem;
-  padding-top: 0.5rem;
-  border-top: 1px dashed var(--app-border);
+.condition-head input[type="text"] {
+  flex: 1;
 }
 
-.effect-hints {
-  margin-top: 0.5rem;
-}
-
-.grid-2 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.5rem;
-}
-
+// Files
 .files-list {
   list-style: none;
   padding: 0;
   margin: 0 0 0.6rem;
   display: grid;
-  gap: 0.3rem;
+  gap: 0.5rem;
 }
 
 .files-list li {
   display: flex;
-  justify-content: space-between;
-  gap: 0.5rem;
-  font-size: 0.85rem;
-  padding: 0.3rem 0.5rem;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  padding: 0.5rem 0.6rem;
   border: 1px solid var(--app-border);
   border-radius: 8px;
 }
 
-.file-guid {
+.file-info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.file-name {
+  font-weight: 600;
+}
+
+.file-type {
+  font-size: 0.8rem;
   color: var(--app-muted-text);
-  font-family: monospace;
-  font-size: 0.75rem;
+  background: color-mix(in srgb, var(--app-surface) 70%, var(--app-accent));
+  padding: 0.1rem 0.5rem;
+  border-radius: 999px;
+  white-space: nowrap;
+}
+
+.file-preview {
+  max-width: 240px;
+  max-height: 180px;
+  border-radius: 8px;
+  border: 1px solid var(--app-border);
+  object-fit: contain;
+  align-self: flex-start;
+}
+
+.file-preview-audio {
+  width: 100%;
+  max-width: 320px;
+}
+
+.upload-button {
+  @include cm.button-base();
+  display: inline-block;
+  background: transparent;
+  border: 1px solid var(--app-border);
+  color: inherit;
+  white-space: nowrap;
+}
+
+.upload-button.busy {
+  opacity: 0.6;
+  cursor: wait;
 }
 
 .hint-note {

--- a/src/app/constructor/game-editor.component.scss
+++ b/src/app/constructor/game-editor.component.scss
@@ -124,13 +124,46 @@ select {
 .level-summary {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+  gap: 0.6rem;
   flex-wrap: wrap;
   padding: 0.7rem 0.85rem;
   cursor: pointer;
   user-select: none;
   font-weight: 600;
+}
+
+.level-title {
+  flex: 1;
+}
+
+.drag-handle {
+  cursor: grab;
+  font-size: 1rem;
+  line-height: 1;
+  opacity: 0.7;
+}
+
+.drag-handle:active {
+  cursor: grabbing;
+}
+
+.ghost-button.icon {
+  padding: 0.3rem 0.5rem;
+  line-height: 1;
+}
+
+// CDK drag-drop
+.cdk-drag-preview {
+  @include cm.surface-card(12px, 0);
+  box-shadow: 0 12px 32px rgba(16, 24, 40, 0.25);
+}
+
+.cdk-drag-placeholder {
+  opacity: 0.4;
+}
+
+.cdk-drag-animating {
+  transition: transform 0.2s cubic-bezier(0, 0, 0.2, 1);
 }
 
 .level-summary::marker {

--- a/src/app/constructor/game-editor.component.ts
+++ b/src/app/constructor/game-editor.component.ts
@@ -1,13 +1,14 @@
 import {Component, OnDestroy, OnInit} from "@angular/core";
 import {FormsModule} from "@angular/forms";
-import {RouterLink} from "@angular/router";
-import {ActivatedRoute, ParamMap} from "@angular/router";
+import {ActivatedRoute, ParamMap, RouterLink} from "@angular/router";
 import {Subscription} from "rxjs";
-import {HttpErrorResponse} from "@angular/common/http";
 import {ConstructorService} from "./constructor.service";
 import {HintEditorComponent} from "./hint-editor.component";
+import {HintTypePickerComponent} from "./hint-type-picker.component";
+import {EffectsEditorComponent} from "./effects-editor.component";
 import {FullGame, HintType, Level, ScenarioConditionType} from "../domain/game.models";
 import {
+  CONTENT_TYPE_LABELS,
   EffectsPayload,
   generateEffectId,
   HintPayload,
@@ -20,20 +21,13 @@ import {
   validateScenario,
 } from "./constructor.models";
 import {SnackbarService} from "../snackbar/snackbar.service";
-
-interface EditorEffects {
-  id: string;
-  hints: HintPayload[];
-  bonus_minutes: number;
-  level_up: boolean;
-  next_level: string | null;
-}
+import {HttpAdapter} from "../http/http.adapter";
+import {AppEmoji, CONTENT_TYPE_EMOJI} from "../ui/emoji";
 
 interface EditorCondition {
-  type: ScenarioConditionType;
-  keysText: string;
-  action_time: number | null;
-  effects: EditorEffects;
+  keysText: string;            // EFFECTS_KEY
+  action_time: number | null;  // EFFECTS_TIMER
+  effects: EffectsPayload;
 }
 
 interface EditorTimeHint {
@@ -43,20 +37,30 @@ interface EditorTimeHint {
 
 interface EditorLevel {
   id: string;
+  /** Keys of the single WIN_KEY condition ("Ключ уровня"). */
+  winKeysText: string;
+  /** action_time of the winning timer ("Время автозавершения уровня"). */
+  autoFinishTime: number | null;
+  /** Preserved effects payload of the winning timer (round-trip safety). */
+  autoFinishEffects: EffectsPayload;
+  /** EFFECTS_KEY conditions. */
+  keyConditions: EditorCondition[];
+  /** Non-winning EFFECTS_TIMER conditions. */
+  timerConditions: EditorCondition[];
   time_hints: EditorTimeHint[];
-  conditions: EditorCondition[];
 }
+
+type FilePreviewKind = "image" | "video" | "audio" | "none";
 
 @Component({
   selector: "app-game-editor",
   standalone: true,
-  imports: [FormsModule, RouterLink, HintEditorComponent],
+  imports: [FormsModule, RouterLink, HintEditorComponent, HintTypePickerComponent, EffectsEditorComponent],
   templateUrl: "./game-editor.component.html",
   styleUrl: "./game-editor.component.scss",
 })
 export class GameEditorComponent implements OnInit, OnDestroy {
-  protected readonly ScenarioConditionType = ScenarioConditionType;
-  protected readonly statusLabels = STATUS_LABELS;
+  protected readonly AppEmoji = AppEmoji;
 
   gameId!: number;
   game: FullGame | undefined;
@@ -77,6 +81,7 @@ export class GameEditorComponent implements OnInit, OnDestroy {
     private constructorService: ConstructorService,
     private route: ActivatedRoute,
     private snackbar: SnackbarService,
+    private http: HttpAdapter,
   ) {
   }
 
@@ -152,29 +157,58 @@ export class GameEditorComponent implements OnInit, OnDestroy {
 
   private toEditorLevel(level: Level): EditorLevel {
     const scenario = level.scenario;
-    return {
+    const editor: EditorLevel = {
       id: scenario?.id ?? level.name_id,
+      winKeysText: "",
+      autoFinishTime: null,
+      autoFinishEffects: this.newEffects(),
+      keyConditions: [],
+      timerConditions: [],
       time_hints: (scenario?.time_hints ?? []).map(th => ({
         time: th.time,
         hint: (th.hint ?? []) as HintPayload[],
       })),
-      conditions: (scenario?.conditions ?? []).map(c => this.toEditorCondition(c)),
     };
+
+    for (const condition of (scenario?.conditions ?? []) as any[]) {
+      const keys: string[] = Array.isArray(condition.keys) ? condition.keys : [];
+      const effects = this.toEffects(condition.effects);
+      const actionTime = typeof condition.action_time === "number" ? condition.action_time : null;
+
+      switch (condition.type) {
+        case ScenarioConditionType.winKey:
+          editor.winKeysText = [editor.winKeysText, keys.join(" ")].filter(Boolean).join(" ");
+          break;
+        case ScenarioConditionType.effectsKey:
+          editor.keyConditions.push({keysText: keys.join(" "), action_time: null, effects});
+          break;
+        case ScenarioConditionType.effectsTimer:
+          if (effects.level_up && editor.autoFinishTime === null) {
+            editor.autoFinishTime = actionTime;
+            editor.autoFinishEffects = effects;
+          } else {
+            // Extra winning timers are invalid per the contract — demote them.
+            editor.timerConditions.push({
+              keysText: "",
+              action_time: actionTime,
+              effects: {...effects, level_up: false, next_level: null},
+            });
+          }
+          break;
+      }
+    }
+
+    return editor;
   }
 
-  private toEditorCondition(condition: any): EditorCondition {
-    const rawEffects = Array.isArray(condition.effects) ? condition.effects[0] : condition.effects;
+  private toEffects(raw: any): EffectsPayload {
+    const effects = Array.isArray(raw) ? raw[0] : raw;
     return {
-      type: condition.type,
-      keysText: Array.isArray(condition.keys) ? condition.keys.join(" ") : "",
-      action_time: typeof condition.action_time === "number" ? condition.action_time : null,
-      effects: {
-        id: rawEffects?.id ?? generateEffectId(),
-        hints: (rawEffects?.hints ?? rawEffects?.hints_ ?? []) as HintPayload[],
-        bonus_minutes: typeof rawEffects?.bonus_minutes === "number" ? rawEffects.bonus_minutes : 0,
-        level_up: rawEffects?.level_up === true,
-        next_level: rawEffects?.next_level ?? null,
-      },
+      id: effects?.id ?? generateEffectId(),
+      hints: (effects?.hints ?? effects?.hints_ ?? []) as HintPayload[],
+      bonus_minutes: typeof effects?.bonus_minutes === "number" ? effects.bonus_minutes : 0,
+      level_up: effects?.level_up === true,
+      next_level: effects?.next_level ?? null,
     };
   }
 
@@ -214,16 +248,14 @@ export class GameEditorComponent implements OnInit, OnDestroy {
   // -------------------------------------------------------------------------
 
   addLevel() {
-    const id = this.uniqueLevelId();
     this.levels.push({
-      id,
-      time_hints: [{time: 0, hint: [this.newHint()]}],
-      conditions: [{
-        type: ScenarioConditionType.winKey,
-        keysText: "",
-        action_time: null,
-        effects: this.newEffects(),
-      }],
+      id: this.uniqueLevelId(),
+      winKeysText: "",
+      autoFinishTime: null,
+      autoFinishEffects: this.newEffects(),
+      keyConditions: [],
+      timerConditions: [],
+      time_hints: [{time: 0, hint: []}],
     });
   }
 
@@ -251,21 +283,36 @@ export class GameEditorComponent implements OnInit, OnDestroy {
     return id;
   }
 
+  levelIdsExcept(level: EditorLevel): string[] {
+    return this.levels.map(l => l.id).filter(id => id !== level.id);
+  }
+
+  conditionsCount(level: EditorLevel): number {
+    return (parseKeys(level.winKeysText).length > 0 ? 1 : 0)
+      + (level.autoFinishTime != null ? 1 : 0)
+      + level.keyConditions.length
+      + level.timerConditions.length;
+  }
+
+  hintsCount(level: EditorLevel): number {
+    return level.time_hints.length;
+  }
+
   // -------------------------------------------------------------------------
   // Time hints
   // -------------------------------------------------------------------------
 
   addTimeHint(level: EditorLevel) {
     const maxTime = level.time_hints.reduce((m, th) => Math.max(m, th.time), -1);
-    level.time_hints.push({time: maxTime + 5, hint: [this.newHint()]});
+    level.time_hints.push({time: maxTime + 5, hint: []});
   }
 
   removeTimeHint(level: EditorLevel, index: number) {
     level.time_hints.splice(index, 1);
   }
 
-  addHint(timeHint: EditorTimeHint) {
-    timeHint.hint.push(this.newHint());
+  addHint(timeHint: EditorTimeHint, type: HintType) {
+    timeHint.hint.push({type});
   }
 
   removeHint(timeHint: EditorTimeHint, index: number) {
@@ -276,52 +323,23 @@ export class GameEditorComponent implements OnInit, OnDestroy {
   // Conditions
   // -------------------------------------------------------------------------
 
-  addCondition(level: EditorLevel) {
-    level.conditions.push({
-      type: ScenarioConditionType.effectsKey,
-      keysText: "",
-      action_time: null,
-      effects: this.newEffects(),
-    });
+  addKeyCondition(level: EditorLevel) {
+    level.keyConditions.push({keysText: "", action_time: null, effects: this.newEffects()});
   }
 
-  removeCondition(level: EditorLevel, index: number) {
-    level.conditions.splice(index, 1);
+  removeKeyCondition(level: EditorLevel, index: number) {
+    level.keyConditions.splice(index, 1);
   }
 
-  onConditionTypeChange(condition: EditorCondition) {
-    if (!condition.effects?.id) {
-      condition.effects = this.newEffects();
-    }
+  addTimerCondition(level: EditorLevel) {
+    level.timerConditions.push({keysText: "", action_time: null, effects: this.newEffects()});
   }
 
-  isKeyCondition(condition: EditorCondition): boolean {
-    return condition.type === ScenarioConditionType.winKey
-      || condition.type === ScenarioConditionType.effectsKey;
+  removeTimerCondition(level: EditorLevel, index: number) {
+    level.timerConditions.splice(index, 1);
   }
 
-  hasEffects(condition: EditorCondition): boolean {
-    return condition.type === ScenarioConditionType.effectsKey
-      || condition.type === ScenarioConditionType.effectsTimer;
-  }
-
-  isTimer(condition: EditorCondition): boolean {
-    return condition.type === ScenarioConditionType.effectsTimer;
-  }
-
-  addEffectHint(condition: EditorCondition) {
-    condition.effects.hints.push(this.newHint());
-  }
-
-  removeEffectHint(condition: EditorCondition, index: number) {
-    condition.effects.hints.splice(index, 1);
-  }
-
-  private newHint(): HintPayload {
-    return {type: HintType.text, text: ""};
-  }
-
-  private newEffects(): EditorEffects {
+  private newEffects(): EffectsPayload {
     return {
       id: generateEffectId(),
       hints: [],
@@ -345,7 +363,7 @@ export class GameEditorComponent implements OnInit, OnDestroy {
     this.isUploading = true;
     this.constructorService.uploadFile(this.gameId, file).subscribe({
       next: uploaded => {
-        this.files = [...this.files.filter(f => f.guid !== uploaded.guid), uploaded];
+        this.addFile(uploaded);
         this.isUploading = false;
         this.snackbar.success(`Файл загружен: ${uploaded.original_filename}${uploaded.extension}`);
         input.value = "";
@@ -357,8 +375,48 @@ export class GameEditorComponent implements OnInit, OnDestroy {
     });
   }
 
+  /** A file uploaded from inside a hint editor — register it in the list. */
+  onHintFileUploaded(file: UploadedFile) {
+    this.addFile(file);
+  }
+
+  private addFile(file: UploadedFile) {
+    this.files = [...this.files.filter(f => f.guid !== file.guid), file];
+  }
+
   fileLabel(file: UploadedFile): string {
     return `${file.original_filename}${file.extension || ""}`;
+  }
+
+  fileEmoji(file: UploadedFile): string {
+    if (file.content_type && CONTENT_TYPE_EMOJI[file.content_type]) {
+      return CONTENT_TYPE_EMOJI[file.content_type];
+    }
+    return AppEmoji.files;
+  }
+
+  fileContentTypeLabel(file: UploadedFile): string | undefined {
+    if (!file.content_type) {
+      return undefined;
+    }
+    return CONTENT_TYPE_LABELS[file.content_type] ?? file.content_type;
+  }
+
+  filePreviewKind(file: UploadedFile): FilePreviewKind {
+    switch (file.content_type) {
+      case "photo":
+        return "image";
+      case "video":
+        return "video";
+      case "audio":
+        return "audio";
+      default:
+        return "none";
+    }
+  }
+
+  fileUrl(file: UploadedFile): string {
+    return this.http.getFileUrl(this.gameId, file.guid);
   }
 
   // -------------------------------------------------------------------------
@@ -376,7 +434,7 @@ export class GameEditorComponent implements OnInit, OnDestroy {
           time: Number(th.time),
           hint: th.hint.map(h => this.cleanHint(h)),
         })),
-        conditions: level.conditions.map(c => this.buildCondition(c)),
+        conditions: this.buildConditions(level),
       })),
       files: this.files.map(f => ({
         guid: f.guid,
@@ -389,22 +447,42 @@ export class GameEditorComponent implements OnInit, OnDestroy {
     };
   }
 
-  private buildCondition(c: EditorCondition) {
-    if (c.type === ScenarioConditionType.winKey) {
-      return {type: c.type, keys: parseKeys(c.keysText)};
+  private buildConditions(level: EditorLevel) {
+    const conditions: any[] = [];
+
+    const winKeys = parseKeys(level.winKeysText);
+    if (winKeys.length > 0) {
+      conditions.push({type: ScenarioConditionType.winKey, keys: winKeys});
     }
-    if (c.type === ScenarioConditionType.effectsKey) {
-      return {type: c.type, keys: parseKeys(c.keysText), effects: this.buildEffects(c.effects)};
+
+    if (level.autoFinishTime != null) {
+      conditions.push({
+        type: ScenarioConditionType.effectsTimer,
+        action_time: Number(level.autoFinishTime),
+        effects: {...this.buildEffects(level.autoFinishEffects), level_up: true},
+      });
     }
-    // effects timer
-    return {
-      type: c.type,
-      action_time: c.action_time != null ? Number(c.action_time) : undefined,
-      effects: this.buildEffects(c.effects),
-    };
+
+    level.keyConditions.forEach(c => {
+      conditions.push({
+        type: ScenarioConditionType.effectsKey,
+        keys: parseKeys(c.keysText),
+        effects: this.buildEffects(c.effects),
+      });
+    });
+
+    level.timerConditions.forEach(c => {
+      conditions.push({
+        type: ScenarioConditionType.effectsTimer,
+        action_time: c.action_time != null ? Number(c.action_time) : undefined,
+        effects: {...this.buildEffects(c.effects), level_up: false, next_level: null},
+      });
+    });
+
+    return conditions;
   }
 
-  private buildEffects(e: EditorEffects): EffectsPayload {
+  private buildEffects(e: EffectsPayload): EffectsPayload {
     return {
       id: e.id,
       hints: e.hints.map(h => this.cleanHint(h)),
@@ -496,11 +574,6 @@ export class GameEditorComponent implements OnInit, OnDestroy {
       next: () => {
         this.snackbar.success("Статус изменён");
         this.load();
-      },
-      error: err => {
-        if (err instanceof HttpErrorResponse) {
-          // handled by global error handler
-        }
       },
     });
   }

--- a/src/app/constructor/game-editor.component.ts
+++ b/src/app/constructor/game-editor.component.ts
@@ -15,6 +15,8 @@ import {
   generateEffectId,
   HintPayload,
   isEditableStatus,
+  isValidKey,
+  isValidLevelId,
   parseKeys,
   SCENARIO_MODEL_VERSION,
   ScenarioPayload,
@@ -228,29 +230,54 @@ export class GameEditorComponent implements OnInit, OnDestroy {
       return provided as UploadedFile[];
     }
 
-    const guids = new Set<string>();
+    // The server doesn't return file metadata here, so derive at least the
+    // content type from the hint types referencing each guid (for previews).
+    const kinds = new Map<string, string | undefined>();
+    const note = (h: HintPayload) => {
+      if (h.file_guid && !kinds.has(h.file_guid)) {
+        kinds.set(h.file_guid, this.contentTypeForHintType(h.type));
+      }
+      if (h.thumb_guid && !kinds.has(h.thumb_guid)) {
+        kinds.set(h.thumb_guid, "photo");
+      }
+    };
+
     (game.levels ?? []).forEach(level => {
       (level.scenario?.time_hints ?? []).forEach(th => {
-        (th.hint ?? []).forEach(h => {
-          if (h.file_guid) guids.add(h.file_guid);
-          if (h.thumb_guid) guids.add(h.thumb_guid);
-        });
+        (th.hint ?? []).forEach(note);
       });
       (level.scenario?.conditions ?? []).forEach((c: any) => {
         const eff = Array.isArray(c.effects) ? c.effects[0] : c.effects;
         const hints = eff?.hints ?? eff?.hints_ ?? [];
-        hints.forEach((h: HintPayload) => {
-          if (h.file_guid) guids.add(h.file_guid);
-          if (h.thumb_guid) guids.add(h.thumb_guid);
-        });
+        hints.forEach((h: HintPayload) => note(h));
       });
     });
 
-    return Array.from(guids).map(guid => ({
+    return Array.from(kinds.entries()).map(([guid, contentType]) => ({
       guid,
       original_filename: guid,
       extension: "",
+      content_type: contentType,
     }));
+  }
+
+  private contentTypeForHintType(type: HintType): string | undefined {
+    switch (type) {
+      case HintType.photo:
+      case HintType.sticker:
+        return "photo";
+      case HintType.video:
+      case HintType.animation:
+      case HintType.video_note:
+        return "video";
+      case HintType.audio:
+      case HintType.voice:
+        return "audio";
+      case HintType.document:
+        return "document";
+      default:
+        return undefined;
+    }
   }
 
   // -------------------------------------------------------------------------
@@ -298,6 +325,24 @@ export class GameEditorComponent implements OnInit, OnDestroy {
 
   allLevelIds(): string[] {
     return this.levels.map(l => l.id);
+  }
+
+  // -------------------------------------------------------------------------
+  // Live field validation
+  // -------------------------------------------------------------------------
+
+  /** Auto-capitalize keys as the user types. */
+  upperKeys(value: string): string {
+    return value.toUpperCase();
+  }
+
+  /** Empty is fine (no condition emitted); every entered key must match. */
+  areKeysOk(text: string): boolean {
+    return parseKeys(text).every(isValidKey);
+  }
+
+  isLevelIdOk(id: string): boolean {
+    return isValidLevelId(id);
   }
 
   conditionsCount(level: EditorLevel): number {
@@ -398,6 +443,10 @@ export class GameEditorComponent implements OnInit, OnDestroy {
   }
 
   fileLabel(file: UploadedFile): string {
+    const hasName = file.original_filename && file.original_filename !== file.guid;
+    if (!hasName) {
+      return `файл ${file.guid.slice(0, 8)}…`;
+    }
     return `${file.original_filename}${file.extension || ""}`;
   }
 

--- a/src/app/constructor/game-editor.component.ts
+++ b/src/app/constructor/game-editor.component.ts
@@ -41,6 +41,7 @@ interface EditorTimeHint {
 }
 
 interface EditorLevel {
+  expanded: boolean;
   id: string;
   /** Keys of the single WIN_KEY condition ("Ключ уровня"). */
   winKeysText: string;
@@ -88,6 +89,11 @@ export class GameEditorComponent implements OnInit, OnDestroy {
   startAtLocal = "";
   validationErrors: string[] = [];
 
+  /** guid -> local blob URL, for instant previews right after upload
+   *  (the CDN copy may not be readable for a moment). Shared with child
+   *  hint editors so their previews resolve to the local copy too. */
+  objectUrls = new Map<string, string>();
+
   private routeSubscription: Subscription | undefined;
 
   constructor(
@@ -110,6 +116,7 @@ export class GameEditorComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
+    this.objectUrls.forEach(url => URL.revokeObjectURL(url));
     this.routeSubscription?.unsubscribe();
   }
 
@@ -185,6 +192,7 @@ export class GameEditorComponent implements OnInit, OnDestroy {
   private toEditorLevel(level: Level): EditorLevel {
     const scenario = level.scenario;
     const editor: EditorLevel = {
+      expanded: false,
       id: scenario?.id ?? level.name_id,
       winKeysText: "",
       autoFinishTime: null,
@@ -301,6 +309,7 @@ export class GameEditorComponent implements OnInit, OnDestroy {
 
   addLevel() {
     this.levels.push({
+      expanded: true,
       id: this.uniqueLevelId(),
       winKeysText: "",
       autoFinishTime: null,
@@ -309,6 +318,14 @@ export class GameEditorComponent implements OnInit, OnDestroy {
       timerConditions: [],
       time_hints: [{time: 0, hint: []}],
     });
+  }
+
+  onLevelToggle(level: EditorLevel, event: Event) {
+    level.expanded = (event.target as HTMLDetailsElement).open;
+  }
+
+  anyLevelExpanded(): boolean {
+    return this.levels.some(l => l.expanded);
   }
 
   removeLevel(index: number) {
@@ -437,6 +454,9 @@ export class GameEditorComponent implements OnInit, OnDestroy {
     this.constructorService.uploadFile(this.gameId, file).subscribe({
       next: uploaded => {
         this.addFile(uploaded);
+        if (uploaded?.guid) {
+          this.objectUrls.set(uploaded.guid, URL.createObjectURL(file));
+        }
         this.isUploading = false;
         this.snackbar.success(`Файл загружен: ${uploaded.original_filename}${uploaded.extension}`);
         input.value = "";
@@ -498,7 +518,7 @@ export class GameEditorComponent implements OnInit, OnDestroy {
   }
 
   fileUrl(file: UploadedFile): string {
-    return this.http.getFileUrl(this.gameId, file.guid);
+    return this.objectUrls.get(file.guid) ?? this.http.getFileUrl(this.gameId, file.guid);
   }
 
   // -------------------------------------------------------------------------

--- a/src/app/constructor/game-editor.component.ts
+++ b/src/app/constructor/game-editor.component.ts
@@ -2,10 +2,12 @@ import {Component, OnDestroy, OnInit} from "@angular/core";
 import {FormsModule} from "@angular/forms";
 import {ActivatedRoute, ParamMap, RouterLink} from "@angular/router";
 import {Subscription} from "rxjs";
+import {CdkDragDrop, DragDropModule, moveItemInArray} from "@angular/cdk/drag-drop";
 import {ConstructorService} from "./constructor.service";
 import {HintEditorComponent} from "./hint-editor.component";
 import {HintTypePickerComponent} from "./hint-type-picker.component";
 import {EffectsEditorComponent} from "./effects-editor.component";
+import {ImageLightboxComponent} from "../ui/image-lightbox.component";
 import {FullGame, HintType, Level, ScenarioConditionType} from "../domain/game.models";
 import {
   CONTENT_TYPE_LABELS,
@@ -55,7 +57,15 @@ type FilePreviewKind = "image" | "video" | "audio" | "none";
 @Component({
   selector: "app-game-editor",
   standalone: true,
-  imports: [FormsModule, RouterLink, HintEditorComponent, HintTypePickerComponent, EffectsEditorComponent],
+  imports: [
+    FormsModule,
+    RouterLink,
+    DragDropModule,
+    HintEditorComponent,
+    HintTypePickerComponent,
+    EffectsEditorComponent,
+    ImageLightboxComponent,
+  ],
   templateUrl: "./game-editor.component.html",
   styleUrl: "./game-editor.component.scss",
 })
@@ -268,8 +278,11 @@ export class GameEditorComponent implements OnInit, OnDestroy {
     if (target < 0 || target >= this.levels.length) {
       return;
     }
-    const [item] = this.levels.splice(index, 1);
-    this.levels.splice(target, 0, item);
+    moveItemInArray(this.levels, index, target);
+  }
+
+  onLevelDrop(event: CdkDragDrop<EditorLevel[]>) {
+    moveItemInArray(this.levels, event.previousIndex, event.currentIndex);
   }
 
   private uniqueLevelId(): string {
@@ -283,8 +296,8 @@ export class GameEditorComponent implements OnInit, OnDestroy {
     return id;
   }
 
-  levelIdsExcept(level: EditorLevel): string[] {
-    return this.levels.map(l => l.id).filter(id => id !== level.id);
+  allLevelIds(): string[] {
+    return this.levels.map(l => l.id);
   }
 
   conditionsCount(level: EditorLevel): number {

--- a/src/app/constructor/game-editor.component.ts
+++ b/src/app/constructor/game-editor.component.ts
@@ -1,0 +1,513 @@
+import {Component, OnDestroy, OnInit} from "@angular/core";
+import {FormsModule} from "@angular/forms";
+import {RouterLink} from "@angular/router";
+import {ActivatedRoute, ParamMap} from "@angular/router";
+import {Subscription} from "rxjs";
+import {HttpErrorResponse} from "@angular/common/http";
+import {ConstructorService} from "./constructor.service";
+import {HintEditorComponent} from "./hint-editor.component";
+import {FullGame, HintType, Level, ScenarioConditionType} from "../domain/game.models";
+import {
+  EffectsPayload,
+  generateEffectId,
+  HintPayload,
+  isEditableStatus,
+  parseKeys,
+  SCENARIO_MODEL_VERSION,
+  ScenarioPayload,
+  STATUS_LABELS,
+  UploadedFile,
+  validateScenario,
+} from "./constructor.models";
+import {SnackbarService} from "../snackbar/snackbar.service";
+
+interface EditorEffects {
+  id: string;
+  hints: HintPayload[];
+  bonus_minutes: number;
+  level_up: boolean;
+  next_level: string | null;
+}
+
+interface EditorCondition {
+  type: ScenarioConditionType;
+  keysText: string;
+  action_time: number | null;
+  effects: EditorEffects;
+}
+
+interface EditorTimeHint {
+  time: number;
+  hint: HintPayload[];
+}
+
+interface EditorLevel {
+  id: string;
+  time_hints: EditorTimeHint[];
+  conditions: EditorCondition[];
+}
+
+@Component({
+  selector: "app-game-editor",
+  standalone: true,
+  imports: [FormsModule, RouterLink, HintEditorComponent],
+  templateUrl: "./game-editor.component.html",
+  styleUrl: "./game-editor.component.scss",
+})
+export class GameEditorComponent implements OnInit, OnDestroy {
+  protected readonly ScenarioConditionType = ScenarioConditionType;
+  protected readonly statusLabels = STATUS_LABELS;
+
+  gameId!: number;
+  game: FullGame | undefined;
+  isLoading = false;
+  isSaving = false;
+  isUploading = false;
+
+  name = "";
+  levels: EditorLevel[] = [];
+  files: UploadedFile[] = [];
+
+  startAtLocal = "";
+  validationErrors: string[] = [];
+
+  private routeSubscription: Subscription | undefined;
+
+  constructor(
+    private constructorService: ConstructorService,
+    private route: ActivatedRoute,
+    private snackbar: SnackbarService,
+  ) {
+  }
+
+  ngOnInit(): void {
+    this.routeSubscription = this.route.paramMap.subscribe((params: ParamMap) => {
+      const id = Number(params.get("id"));
+      if (Number.isNaN(id)) {
+        return;
+      }
+      this.gameId = id;
+      this.load();
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.routeSubscription?.unsubscribe();
+  }
+
+  get status(): string | undefined {
+    return this.game?.status;
+  }
+
+  statusLabel(status: string | undefined): string {
+    if (!status) {
+      return "";
+    }
+    return STATUS_LABELS[status] ?? status;
+  }
+
+  get isEditable(): boolean {
+    return isEditableStatus(this.game?.status);
+  }
+
+  get canOpenWaivers(): boolean {
+    return this.isEditable && this.game?.status !== "getting_waivers";
+  }
+
+  get canComplete(): boolean {
+    return this.game?.status === "finished";
+  }
+
+  // -------------------------------------------------------------------------
+  // Loading & state mapping
+  // -------------------------------------------------------------------------
+
+  load() {
+    this.isLoading = true;
+    this.constructorService.getGame(this.gameId).subscribe({
+      next: game => {
+        this.applyGame(game);
+        this.isLoading = false;
+      },
+      error: () => {
+        this.isLoading = false;
+      },
+    });
+  }
+
+  private applyGame(game: FullGame) {
+    this.game = game;
+    this.name = game.name;
+    this.startAtLocal = game.start_at ? this.toLocalInput(game.start_at) : "";
+
+    const rawLevels = [...(game.levels ?? [])].sort(
+      (a, b) => (a.number_in_game ?? 0) - (b.number_in_game ?? 0),
+    );
+    this.levels = rawLevels.map(level => this.toEditorLevel(level));
+
+    // Reconstruct the files list: prefer a server-provided files array if any,
+    // otherwise rebuild best-effort entries from the guids referenced in hints.
+    this.files = this.collectFiles(game);
+  }
+
+  private toEditorLevel(level: Level): EditorLevel {
+    const scenario = level.scenario;
+    return {
+      id: scenario?.id ?? level.name_id,
+      time_hints: (scenario?.time_hints ?? []).map(th => ({
+        time: th.time,
+        hint: (th.hint ?? []) as HintPayload[],
+      })),
+      conditions: (scenario?.conditions ?? []).map(c => this.toEditorCondition(c)),
+    };
+  }
+
+  private toEditorCondition(condition: any): EditorCondition {
+    const rawEffects = Array.isArray(condition.effects) ? condition.effects[0] : condition.effects;
+    return {
+      type: condition.type,
+      keysText: Array.isArray(condition.keys) ? condition.keys.join(" ") : "",
+      action_time: typeof condition.action_time === "number" ? condition.action_time : null,
+      effects: {
+        id: rawEffects?.id ?? generateEffectId(),
+        hints: (rawEffects?.hints ?? rawEffects?.hints_ ?? []) as HintPayload[],
+        bonus_minutes: typeof rawEffects?.bonus_minutes === "number" ? rawEffects.bonus_minutes : 0,
+        level_up: rawEffects?.level_up === true,
+        next_level: rawEffects?.next_level ?? null,
+      },
+    };
+  }
+
+  private collectFiles(game: FullGame): UploadedFile[] {
+    const provided = (game as any).files;
+    if (Array.isArray(provided) && provided.length > 0) {
+      return provided as UploadedFile[];
+    }
+
+    const guids = new Set<string>();
+    (game.levels ?? []).forEach(level => {
+      (level.scenario?.time_hints ?? []).forEach(th => {
+        (th.hint ?? []).forEach(h => {
+          if (h.file_guid) guids.add(h.file_guid);
+          if (h.thumb_guid) guids.add(h.thumb_guid);
+        });
+      });
+      (level.scenario?.conditions ?? []).forEach((c: any) => {
+        const eff = Array.isArray(c.effects) ? c.effects[0] : c.effects;
+        const hints = eff?.hints ?? eff?.hints_ ?? [];
+        hints.forEach((h: HintPayload) => {
+          if (h.file_guid) guids.add(h.file_guid);
+          if (h.thumb_guid) guids.add(h.thumb_guid);
+        });
+      });
+    });
+
+    return Array.from(guids).map(guid => ({
+      guid,
+      original_filename: guid,
+      extension: "",
+    }));
+  }
+
+  // -------------------------------------------------------------------------
+  // Level operations
+  // -------------------------------------------------------------------------
+
+  addLevel() {
+    const id = this.uniqueLevelId();
+    this.levels.push({
+      id,
+      time_hints: [{time: 0, hint: [this.newHint()]}],
+      conditions: [{
+        type: ScenarioConditionType.winKey,
+        keysText: "",
+        action_time: null,
+        effects: this.newEffects(),
+      }],
+    });
+  }
+
+  removeLevel(index: number) {
+    this.levels.splice(index, 1);
+  }
+
+  moveLevel(index: number, delta: number) {
+    const target = index + delta;
+    if (target < 0 || target >= this.levels.length) {
+      return;
+    }
+    const [item] = this.levels.splice(index, 1);
+    this.levels.splice(target, 0, item);
+  }
+
+  private uniqueLevelId(): string {
+    let n = this.levels.length + 1;
+    let id = `level-${n}`;
+    const existing = new Set(this.levels.map(l => l.id));
+    while (existing.has(id)) {
+      n += 1;
+      id = `level-${n}`;
+    }
+    return id;
+  }
+
+  // -------------------------------------------------------------------------
+  // Time hints
+  // -------------------------------------------------------------------------
+
+  addTimeHint(level: EditorLevel) {
+    const maxTime = level.time_hints.reduce((m, th) => Math.max(m, th.time), -1);
+    level.time_hints.push({time: maxTime + 5, hint: [this.newHint()]});
+  }
+
+  removeTimeHint(level: EditorLevel, index: number) {
+    level.time_hints.splice(index, 1);
+  }
+
+  addHint(timeHint: EditorTimeHint) {
+    timeHint.hint.push(this.newHint());
+  }
+
+  removeHint(timeHint: EditorTimeHint, index: number) {
+    timeHint.hint.splice(index, 1);
+  }
+
+  // -------------------------------------------------------------------------
+  // Conditions
+  // -------------------------------------------------------------------------
+
+  addCondition(level: EditorLevel) {
+    level.conditions.push({
+      type: ScenarioConditionType.effectsKey,
+      keysText: "",
+      action_time: null,
+      effects: this.newEffects(),
+    });
+  }
+
+  removeCondition(level: EditorLevel, index: number) {
+    level.conditions.splice(index, 1);
+  }
+
+  onConditionTypeChange(condition: EditorCondition) {
+    if (!condition.effects?.id) {
+      condition.effects = this.newEffects();
+    }
+  }
+
+  isKeyCondition(condition: EditorCondition): boolean {
+    return condition.type === ScenarioConditionType.winKey
+      || condition.type === ScenarioConditionType.effectsKey;
+  }
+
+  hasEffects(condition: EditorCondition): boolean {
+    return condition.type === ScenarioConditionType.effectsKey
+      || condition.type === ScenarioConditionType.effectsTimer;
+  }
+
+  isTimer(condition: EditorCondition): boolean {
+    return condition.type === ScenarioConditionType.effectsTimer;
+  }
+
+  addEffectHint(condition: EditorCondition) {
+    condition.effects.hints.push(this.newHint());
+  }
+
+  removeEffectHint(condition: EditorCondition, index: number) {
+    condition.effects.hints.splice(index, 1);
+  }
+
+  private newHint(): HintPayload {
+    return {type: HintType.text, text: ""};
+  }
+
+  private newEffects(): EditorEffects {
+    return {
+      id: generateEffectId(),
+      hints: [],
+      bonus_minutes: 0,
+      level_up: false,
+      next_level: null,
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // Files
+  // -------------------------------------------------------------------------
+
+  onFileSelected(event: Event) {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    this.isUploading = true;
+    this.constructorService.uploadFile(this.gameId, file).subscribe({
+      next: uploaded => {
+        this.files = [...this.files.filter(f => f.guid !== uploaded.guid), uploaded];
+        this.isUploading = false;
+        this.snackbar.success(`Файл загружен: ${uploaded.original_filename}${uploaded.extension}`);
+        input.value = "";
+      },
+      error: () => {
+        this.isUploading = false;
+        input.value = "";
+      },
+    });
+  }
+
+  fileLabel(file: UploadedFile): string {
+    return `${file.original_filename}${file.extension || ""}`;
+  }
+
+  // -------------------------------------------------------------------------
+  // Saving scenario
+  // -------------------------------------------------------------------------
+
+  private buildScenario(): ScenarioPayload {
+    return {
+      name: this.name.trim(),
+      __model_version__: SCENARIO_MODEL_VERSION,
+      levels: this.levels.map(level => ({
+        id: level.id.trim(),
+        __model_version__: SCENARIO_MODEL_VERSION,
+        time_hints: level.time_hints.map(th => ({
+          time: Number(th.time),
+          hint: th.hint.map(h => this.cleanHint(h)),
+        })),
+        conditions: level.conditions.map(c => this.buildCondition(c)),
+      })),
+      files: this.files.map(f => ({
+        guid: f.guid,
+        original_filename: f.original_filename,
+        extension: f.extension,
+        content_type: f.content_type,
+        mime_type: f.mime_type,
+        sha256: f.sha256,
+      })),
+    };
+  }
+
+  private buildCondition(c: EditorCondition) {
+    if (c.type === ScenarioConditionType.winKey) {
+      return {type: c.type, keys: parseKeys(c.keysText)};
+    }
+    if (c.type === ScenarioConditionType.effectsKey) {
+      return {type: c.type, keys: parseKeys(c.keysText), effects: this.buildEffects(c.effects)};
+    }
+    // effects timer
+    return {
+      type: c.type,
+      action_time: c.action_time != null ? Number(c.action_time) : undefined,
+      effects: this.buildEffects(c.effects),
+    };
+  }
+
+  private buildEffects(e: EditorEffects): EffectsPayload {
+    return {
+      id: e.id,
+      hints: e.hints.map(h => this.cleanHint(h)),
+      bonus_minutes: Number(e.bonus_minutes) || 0,
+      level_up: e.level_up === true,
+      next_level: e.next_level && e.next_level.length > 0 ? e.next_level : null,
+    };
+  }
+
+  /** Drop empty/undefined fields and coerce numbers so the payload is clean. */
+  private cleanHint(hint: HintPayload): HintPayload {
+    const out: HintPayload = {type: hint.type};
+    const copyIf = (key: keyof HintPayload) => {
+      const v = hint[key];
+      if (v !== undefined && v !== null && v !== "") {
+        (out as any)[key] = v;
+      }
+    };
+    copyIf("text");
+    copyIf("title");
+    copyIf("address");
+    copyIf("foursquare_id");
+    copyIf("foursquare_type");
+    copyIf("caption");
+    copyIf("file_guid");
+    copyIf("thumb_guid");
+    copyIf("phone_number");
+    copyIf("first_name");
+    copyIf("last_name");
+    copyIf("vcard");
+    if (typeof hint.latitude === "number") out.latitude = Number(hint.latitude);
+    if (typeof hint.longitude === "number") out.longitude = Number(hint.longitude);
+    if (hint.show_caption_above_media === true) out.show_caption_above_media = true;
+    if (hint.link_preview) out.link_preview = hint.link_preview;
+    return out;
+  }
+
+  save() {
+    const scenario = this.buildScenario();
+    this.validationErrors = validateScenario(scenario);
+    if (this.validationErrors.length > 0) {
+      this.snackbar.error("Исправьте ошибки перед сохранением");
+      return;
+    }
+
+    this.isSaving = true;
+    this.constructorService.saveScenario(this.gameId, scenario).subscribe({
+      next: game => {
+        this.applyGame(game);
+        this.isSaving = false;
+        this.snackbar.success("Сценарий сохранён");
+      },
+      error: () => {
+        this.isSaving = false;
+      },
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Start time & status
+  // -------------------------------------------------------------------------
+
+  saveStartAt() {
+    if (!this.startAtLocal) {
+      this.snackbar.error("Выберите дату и время старта");
+      return;
+    }
+    const iso = new Date(this.startAtLocal).toISOString();
+    this.constructorService.setStartAt(this.gameId, iso).subscribe({
+      next: () => {
+        this.snackbar.success("Время старта сохранено");
+        this.load();
+      },
+    });
+  }
+
+  clearStartAt() {
+    this.constructorService.setStartAt(this.gameId, null).subscribe({
+      next: () => {
+        this.startAtLocal = "";
+        this.snackbar.success("Планируемый старт отменён");
+        this.load();
+      },
+    });
+  }
+
+  changeStatus(status: string) {
+    this.constructorService.setStatus(this.gameId, status).subscribe({
+      next: () => {
+        this.snackbar.success("Статус изменён");
+        this.load();
+      },
+      error: err => {
+        if (err instanceof HttpErrorResponse) {
+          // handled by global error handler
+        }
+      },
+    });
+  }
+
+  private toLocalInput(iso: string): string {
+    const d = new Date(iso);
+    const pad = (n: number) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+  }
+}

--- a/src/app/constructor/game-editor.component.ts
+++ b/src/app/constructor/game-editor.component.ts
@@ -164,7 +164,21 @@ export class GameEditorComponent implements OnInit, OnDestroy {
 
     // Reconstruct the files list: prefer a server-provided files array if any,
     // otherwise rebuild best-effort entries from the guids referenced in hints.
-    this.files = this.collectFiles(game);
+    // Keep files already uploaded this session (they may not yet be referenced
+    // by any hint, so they wouldn't be re-derived from the scenario).
+    this.files = this.mergeFiles(this.files, this.collectFiles(game));
+  }
+
+  /** Merge two file lists by guid; entries in `existing` win (richer metadata). */
+  private mergeFiles(existing: UploadedFile[], incoming: UploadedFile[]): UploadedFile[] {
+    const map = new Map<string, UploadedFile>();
+    for (const f of incoming) {
+      map.set(f.guid, f);
+    }
+    for (const f of existing) {
+      map.set(f.guid, f);
+    }
+    return Array.from(map.values());
   }
 
   private toEditorLevel(level: Level): EditorLevel {
@@ -439,6 +453,10 @@ export class GameEditorComponent implements OnInit, OnDestroy {
   }
 
   private addFile(file: UploadedFile) {
+    if (!file || !file.guid) {
+      this.snackbar.error("Сервер вернул файл без идентификатора");
+      return;
+    }
     this.files = [...this.files.filter(f => f.guid !== file.guid), file];
   }
 

--- a/src/app/constructor/game-editor.component.ts
+++ b/src/app/constructor/game-editor.component.ts
@@ -241,12 +241,12 @@ export class GameEditorComponent implements OnInit, OnDestroy {
   }
 
   private uniqueLevelId(): string {
-    let n = this.levels.length + 1;
-    let id = `level-${n}`;
     const existing = new Set(this.levels.map(l => l.id));
+    let n = this.levels.length + 1;
+    let id = `lvl_${this.gameId}_${n}`;
     while (existing.has(id)) {
       n += 1;
-      id = `level-${n}`;
+      id = `lvl_${this.gameId}_${n}`;
     }
     return id;
   }

--- a/src/app/constructor/game-editor.component.ts
+++ b/src/app/constructor/game-editor.component.ts
@@ -11,6 +11,7 @@ import {ImageLightboxComponent} from "../ui/image-lightbox.component";
 import {FullGame, HintType, Level, ScenarioConditionType} from "../domain/game.models";
 import {
   CONTENT_TYPE_LABELS,
+  describeError,
   EffectsPayload,
   generateEffectId,
   HintPayload,
@@ -440,9 +441,10 @@ export class GameEditorComponent implements OnInit, OnDestroy {
         this.snackbar.success(`Файл загружен: ${uploaded.original_filename}${uploaded.extension}`);
         input.value = "";
       },
-      error: () => {
+      error: err => {
         this.isUploading = false;
         input.value = "";
+        this.snackbar.error(`Не удалось загрузить файл: ${describeError(err)}`);
       },
     });
   }

--- a/src/app/constructor/hint-editor.component.html
+++ b/src/app/constructor/hint-editor.component.html
@@ -8,8 +8,7 @@
 
   @switch (hint.type) {
     @case (HintType.text) {
-      <label>Текст</label>
-      <textarea rows="3" [(ngModel)]="hint.text" [disabled]="disabled"></textarea>
+      <textarea rows="3" [(ngModel)]="hint.text" [disabled]="disabled" placeholder="Текст подсказки"></textarea>
     }
 
     @case (HintType.gps) {

--- a/src/app/constructor/hint-editor.component.html
+++ b/src/app/constructor/hint-editor.component.html
@@ -1,0 +1,104 @@
+<div class="hint-editor">
+  <div class="hint-head">
+    <select class="hint-type" [(ngModel)]="hint.type" (ngModelChange)="onTypeChange()">
+      @for (t of allTypes; track t) {
+        <option [ngValue]="t">{{ typeLabels[t] }}</option>
+      }
+    </select>
+    <button type="button" class="ghost-button danger" (click)="onRemove()">Удалить</button>
+  </div>
+
+  @switch (hint.type) {
+    @case (HintType.text) {
+      <label>Текст</label>
+      <textarea rows="3" [(ngModel)]="hint.text"></textarea>
+    }
+
+    @case (HintType.gps) {
+      <div class="grid-2">
+        <div>
+          <label>Широта</label>
+          <input type="number" step="any" [(ngModel)]="hint.latitude" />
+        </div>
+        <div>
+          <label>Долгота</label>
+          <input type="number" step="any" [(ngModel)]="hint.longitude" />
+        </div>
+      </div>
+    }
+
+    @case (HintType.venue) {
+      <div class="grid-2">
+        <div>
+          <label>Широта</label>
+          <input type="number" step="any" [(ngModel)]="hint.latitude" />
+        </div>
+        <div>
+          <label>Долгота</label>
+          <input type="number" step="any" [(ngModel)]="hint.longitude" />
+        </div>
+      </div>
+      <label>Название</label>
+      <input type="text" [(ngModel)]="hint.title" />
+      <label>Адрес</label>
+      <input type="text" [(ngModel)]="hint.address" />
+      <div class="grid-2">
+        <div>
+          <label>Foursquare ID</label>
+          <input type="text" [(ngModel)]="hint.foursquare_id" />
+        </div>
+        <div>
+          <label>Foursquare type</label>
+          <input type="text" [(ngModel)]="hint.foursquare_type" />
+        </div>
+      </div>
+    }
+
+    @case (HintType.contact) {
+      <label>Телефон</label>
+      <input type="text" [(ngModel)]="hint.phone_number" />
+      <label>Имя</label>
+      <input type="text" [(ngModel)]="hint.first_name" />
+      <label>Фамилия</label>
+      <input type="text" [(ngModel)]="hint.last_name" />
+      <label>vCard</label>
+      <input type="text" [(ngModel)]="hint.vcard" />
+    }
+  }
+
+  @if (needsFile()) {
+    <label>Файл</label>
+    @if (files.length > 0) {
+      <select [(ngModel)]="hint.file_guid">
+        <option [ngValue]="undefined">— выберите файл —</option>
+        @for (f of files; track f.guid) {
+          <option [ngValue]="f.guid">{{ fileLabel(f) }}</option>
+        }
+      </select>
+    } @else {
+      <p class="hint-note">Сначала загрузите файлы в разделе «Файлы» выше.</p>
+    }
+  }
+
+  @if (needsThumb() && files.length > 0) {
+    <label>Превью (thumb)</label>
+    <select [(ngModel)]="hint.thumb_guid">
+      <option [ngValue]="undefined">— нет —</option>
+      @for (f of files; track f.guid) {
+        <option [ngValue]="f.guid">{{ fileLabel(f) }}</option>
+      }
+    </select>
+  }
+
+  @if (needsCaption()) {
+    <label>Подпись</label>
+    <input type="text" [(ngModel)]="hint.caption" />
+  }
+
+  @if (needsCaptionAbove()) {
+    <label class="checkbox">
+      <input type="checkbox" [(ngModel)]="hint.show_caption_above_media" />
+      Подпись над медиа
+    </label>
+  }
+</div>

--- a/src/app/constructor/hint-editor.component.html
+++ b/src/app/constructor/hint-editor.component.html
@@ -13,29 +13,13 @@
     }
 
     @case (HintType.gps) {
-      <div class="grid-2">
-        <div>
-          <label>Широта</label>
-          <input type="number" step="any" [(ngModel)]="hint.latitude" [disabled]="disabled" />
-        </div>
-        <div>
-          <label>Долгота</label>
-          <input type="number" step="any" [(ngModel)]="hint.longitude" [disabled]="disabled" />
-        </div>
-      </div>
+      <label>Координаты (широта, долгота)</label>
+      <input type="text" [(ngModel)]="coords" [disabled]="disabled" placeholder="55.751244, 37.618423" />
     }
 
     @case (HintType.venue) {
-      <div class="grid-2">
-        <div>
-          <label>Широта</label>
-          <input type="number" step="any" [(ngModel)]="hint.latitude" [disabled]="disabled" />
-        </div>
-        <div>
-          <label>Долгота</label>
-          <input type="number" step="any" [(ngModel)]="hint.longitude" [disabled]="disabled" />
-        </div>
-      </div>
+      <label>Координаты (широта, долгота)</label>
+      <input type="text" [(ngModel)]="coords" [disabled]="disabled" placeholder="55.751244, 37.618423" />
       <label>Название</label>
       <input type="text" [(ngModel)]="hint.title" [disabled]="disabled" />
       <label>Адрес</label>
@@ -83,7 +67,7 @@
 
     @switch (previewKind()) {
       @case ("image") {
-        <img class="preview" [src]="previewUrl()" alt="превью" />
+        <app-image-lightbox [src]="previewUrl()!"></app-image-lightbox>
       }
       @case ("video") {
         <video class="preview" [src]="previewUrl()" controls preload="metadata"></video>

--- a/src/app/constructor/hint-editor.component.html
+++ b/src/app/constructor/hint-editor.component.html
@@ -49,20 +49,28 @@
 
   @if (needsFile()) {
     <label>Файл</label>
-    <div class="file-row">
+    @if (currentFileLabel()) {
+      <span class="current-file">{{ currentFileLabel() }}</span>
+    }
+    @if (!disabled) {
+      <div class="file-actions">
+        <label class="upload-button" [class.busy]="isUploading">
+          {{ AppEmoji.upload }} {{ isUploading ? "Загрузка..." : (hint.file_guid ? "Заменить файл" : "Загрузить файл") }}
+          <input type="file" hidden (change)="onUploadSelected($event, 'file')" [disabled]="isUploading" />
+        </label>
+        @if (files.length > 0) {
+          <button type="button" class="link-button" (click)="toggleFileBrowser()">выбрать из загруженных</button>
+        }
+      </div>
+    }
+    @if (showFileBrowser || disabled) {
       <select [(ngModel)]="hint.file_guid" [disabled]="disabled">
         <option [ngValue]="undefined">— выберите файл —</option>
         @for (f of files; track f.guid) {
           <option [ngValue]="f.guid">{{ fileLabel(f) }}</option>
         }
       </select>
-      @if (!disabled) {
-        <label class="upload-button" [class.busy]="isUploading">
-          {{ isUploading ? "Загрузка..." : "Загрузить" }}
-          <input type="file" hidden (change)="onUploadSelected($event, 'file')" [disabled]="isUploading" />
-        </label>
-      }
-    </div>
+    }
 
     @switch (previewKind()) {
       @case ("image") {
@@ -79,20 +87,28 @@
 
   @if (needsThumb()) {
     <label>Превью (thumb)</label>
-    <div class="file-row">
+    @if (currentThumbLabel()) {
+      <span class="current-file">{{ currentThumbLabel() }}</span>
+    }
+    @if (!disabled) {
+      <div class="file-actions">
+        <label class="upload-button" [class.busy]="isUploading">
+          {{ AppEmoji.upload }} {{ hint.thumb_guid ? "Заменить превью" : "Загрузить превью" }}
+          <input type="file" hidden (change)="onUploadSelected($event, 'thumb')" [disabled]="isUploading" />
+        </label>
+        @if (files.length > 0) {
+          <button type="button" class="link-button" (click)="toggleThumbBrowser()">выбрать из загруженных</button>
+        }
+      </div>
+    }
+    @if (showThumbBrowser || disabled) {
       <select [(ngModel)]="hint.thumb_guid" [disabled]="disabled">
         <option [ngValue]="undefined">— нет —</option>
         @for (f of files; track f.guid) {
           <option [ngValue]="f.guid">{{ fileLabel(f) }}</option>
         }
       </select>
-      @if (!disabled) {
-        <label class="upload-button" [class.busy]="isUploading">
-          Загрузить
-          <input type="file" hidden (change)="onUploadSelected($event, 'thumb')" [disabled]="isUploading" />
-        </label>
-      }
-    </div>
+    }
   }
 
   @if (needsCaption()) {

--- a/src/app/constructor/hint-editor.component.html
+++ b/src/app/constructor/hint-editor.component.html
@@ -1,28 +1,26 @@
 <div class="hint-editor">
   <div class="hint-head">
-    <select class="hint-type" [(ngModel)]="hint.type" (ngModelChange)="onTypeChange()">
-      @for (t of allTypes; track t) {
-        <option [ngValue]="t">{{ typeLabels[t] }}</option>
-      }
-    </select>
-    <button type="button" class="ghost-button danger" (click)="onRemove()">Удалить</button>
+    <span class="hint-type">{{ typeEmoji }} {{ typeLabel }}</span>
+    @if (!disabled) {
+      <button type="button" class="ghost-button danger" (click)="onRemove()">Удалить</button>
+    }
   </div>
 
   @switch (hint.type) {
     @case (HintType.text) {
       <label>Текст</label>
-      <textarea rows="3" [(ngModel)]="hint.text"></textarea>
+      <textarea rows="3" [(ngModel)]="hint.text" [disabled]="disabled"></textarea>
     }
 
     @case (HintType.gps) {
       <div class="grid-2">
         <div>
           <label>Широта</label>
-          <input type="number" step="any" [(ngModel)]="hint.latitude" />
+          <input type="number" step="any" [(ngModel)]="hint.latitude" [disabled]="disabled" />
         </div>
         <div>
           <label>Долгота</label>
-          <input type="number" step="any" [(ngModel)]="hint.longitude" />
+          <input type="number" step="any" [(ngModel)]="hint.longitude" [disabled]="disabled" />
         </div>
       </div>
     }
@@ -31,73 +29,97 @@
       <div class="grid-2">
         <div>
           <label>Широта</label>
-          <input type="number" step="any" [(ngModel)]="hint.latitude" />
+          <input type="number" step="any" [(ngModel)]="hint.latitude" [disabled]="disabled" />
         </div>
         <div>
           <label>Долгота</label>
-          <input type="number" step="any" [(ngModel)]="hint.longitude" />
+          <input type="number" step="any" [(ngModel)]="hint.longitude" [disabled]="disabled" />
         </div>
       </div>
       <label>Название</label>
-      <input type="text" [(ngModel)]="hint.title" />
+      <input type="text" [(ngModel)]="hint.title" [disabled]="disabled" />
       <label>Адрес</label>
-      <input type="text" [(ngModel)]="hint.address" />
+      <input type="text" [(ngModel)]="hint.address" [disabled]="disabled" />
       <div class="grid-2">
         <div>
           <label>Foursquare ID</label>
-          <input type="text" [(ngModel)]="hint.foursquare_id" />
+          <input type="text" [(ngModel)]="hint.foursquare_id" [disabled]="disabled" />
         </div>
         <div>
           <label>Foursquare type</label>
-          <input type="text" [(ngModel)]="hint.foursquare_type" />
+          <input type="text" [(ngModel)]="hint.foursquare_type" [disabled]="disabled" />
         </div>
       </div>
     }
 
     @case (HintType.contact) {
       <label>Телефон</label>
-      <input type="text" [(ngModel)]="hint.phone_number" />
+      <input type="text" [(ngModel)]="hint.phone_number" [disabled]="disabled" />
       <label>Имя</label>
-      <input type="text" [(ngModel)]="hint.first_name" />
+      <input type="text" [(ngModel)]="hint.first_name" [disabled]="disabled" />
       <label>Фамилия</label>
-      <input type="text" [(ngModel)]="hint.last_name" />
+      <input type="text" [(ngModel)]="hint.last_name" [disabled]="disabled" />
       <label>vCard</label>
-      <input type="text" [(ngModel)]="hint.vcard" />
+      <input type="text" [(ngModel)]="hint.vcard" [disabled]="disabled" />
     }
   }
 
   @if (needsFile()) {
     <label>Файл</label>
-    @if (files.length > 0) {
-      <select [(ngModel)]="hint.file_guid">
+    <div class="file-row">
+      <select [(ngModel)]="hint.file_guid" [disabled]="disabled">
         <option [ngValue]="undefined">— выберите файл —</option>
         @for (f of files; track f.guid) {
           <option [ngValue]="f.guid">{{ fileLabel(f) }}</option>
         }
       </select>
-    } @else {
-      <p class="hint-note">Сначала загрузите файлы в разделе «Файлы» выше.</p>
+      @if (!disabled) {
+        <label class="upload-button" [class.busy]="isUploading">
+          {{ isUploading ? "Загрузка..." : "Загрузить" }}
+          <input type="file" hidden (change)="onUploadSelected($event, 'file')" [disabled]="isUploading" />
+        </label>
+      }
+    </div>
+
+    @switch (previewKind()) {
+      @case ("image") {
+        <img class="preview" [src]="previewUrl()" alt="превью" />
+      }
+      @case ("video") {
+        <video class="preview" [src]="previewUrl()" controls preload="metadata"></video>
+      }
+      @case ("audio") {
+        <audio class="preview-audio" [src]="previewUrl()" controls preload="metadata"></audio>
+      }
     }
   }
 
-  @if (needsThumb() && files.length > 0) {
+  @if (needsThumb()) {
     <label>Превью (thumb)</label>
-    <select [(ngModel)]="hint.thumb_guid">
-      <option [ngValue]="undefined">— нет —</option>
-      @for (f of files; track f.guid) {
-        <option [ngValue]="f.guid">{{ fileLabel(f) }}</option>
+    <div class="file-row">
+      <select [(ngModel)]="hint.thumb_guid" [disabled]="disabled">
+        <option [ngValue]="undefined">— нет —</option>
+        @for (f of files; track f.guid) {
+          <option [ngValue]="f.guid">{{ fileLabel(f) }}</option>
+        }
+      </select>
+      @if (!disabled) {
+        <label class="upload-button" [class.busy]="isUploading">
+          Загрузить
+          <input type="file" hidden (change)="onUploadSelected($event, 'thumb')" [disabled]="isUploading" />
+        </label>
       }
-    </select>
+    </div>
   }
 
   @if (needsCaption()) {
     <label>Подпись</label>
-    <input type="text" [(ngModel)]="hint.caption" />
+    <input type="text" [(ngModel)]="hint.caption" [disabled]="disabled" />
   }
 
   @if (needsCaptionAbove()) {
     <label class="checkbox">
-      <input type="checkbox" [(ngModel)]="hint.show_caption_above_media" />
+      <input type="checkbox" [(ngModel)]="hint.show_caption_above_media" [disabled]="disabled" />
       Подпись над медиа
     </label>
   }

--- a/src/app/constructor/hint-editor.component.scss
+++ b/src/app/constructor/hint-editor.component.scss
@@ -1,0 +1,67 @@
+@use "../../styles/component-mixins" as cm;
+
+.hint-editor {
+  border: 1px dashed var(--app-border);
+  border-radius: 10px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  background: color-mix(in srgb, var(--app-surface) 92%, transparent);
+}
+
+.hint-head {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.hint-type {
+  @include cm.input-control();
+  flex: 1;
+}
+
+label {
+  font-size: 0.85rem;
+  color: var(--app-muted-text);
+}
+
+label.checkbox {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  color: inherit;
+}
+
+input[type="text"],
+input[type="number"],
+textarea,
+select {
+  @include cm.input-control();
+  width: 100%;
+}
+
+.grid-2 {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+.ghost-button {
+  @include cm.button-base();
+  background: transparent;
+  border: 1px solid var(--app-border);
+  color: inherit;
+}
+
+.ghost-button.danger {
+  color: #c62828;
+  border-color: #c62828;
+}
+
+.hint-note {
+  font-size: 0.85rem;
+  color: var(--app-muted-text);
+  margin: 0;
+}

--- a/src/app/constructor/hint-editor.component.scss
+++ b/src/app/constructor/hint-editor.component.scss
@@ -72,6 +72,29 @@ select {
   cursor: wait;
 }
 
+.file-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.link-button {
+  background: none;
+  border: none;
+  padding: 0;
+  color: var(--app-accent);
+  font-size: 0.85rem;
+  cursor: pointer;
+  border-bottom: 1px dashed currentColor;
+  line-height: 1.2;
+}
+
+.current-file {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
 .preview {
   max-width: 240px;
   max-height: 180px;

--- a/src/app/constructor/hint-editor.component.scss
+++ b/src/app/constructor/hint-editor.component.scss
@@ -18,8 +18,7 @@
 }
 
 .hint-type {
-  @include cm.input-control();
-  flex: 1;
+  font-weight: 600;
 }
 
 label {
@@ -46,6 +45,45 @@ select {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 0.5rem;
+}
+
+.file-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.file-row select {
+  flex: 1;
+}
+
+.upload-button {
+  @include cm.button-base();
+  display: inline-block;
+  background: transparent;
+  border: 1px solid var(--app-border);
+  color: inherit;
+  white-space: nowrap;
+  font-size: 0.85rem;
+}
+
+.upload-button.busy {
+  opacity: 0.6;
+  cursor: wait;
+}
+
+.preview {
+  max-width: 240px;
+  max-height: 180px;
+  border-radius: 8px;
+  border: 1px solid var(--app-border);
+  object-fit: contain;
+  align-self: flex-start;
+}
+
+.preview-audio {
+  width: 100%;
+  max-width: 320px;
 }
 
 .ghost-button {

--- a/src/app/constructor/hint-editor.component.ts
+++ b/src/app/constructor/hint-editor.component.ts
@@ -15,7 +15,7 @@ import {
 import {ConstructorService} from "./constructor.service";
 import {HttpAdapter} from "../http/http.adapter";
 import {SnackbarService} from "../snackbar/snackbar.service";
-import {CONTENT_TYPE_EMOJI, HINT_TYPE_EMOJI} from "../ui/emoji";
+import {AppEmoji, CONTENT_TYPE_EMOJI, HINT_TYPE_EMOJI} from "../ui/emoji";
 import {ImageLightboxComponent} from "../ui/image-lightbox.component";
 
 type PreviewKind = "image" | "video" | "audio" | "none";
@@ -31,13 +31,18 @@ export class HintEditorComponent {
   @Input({required: true}) hint!: HintPayload;
   @Input() files: UploadedFile[] = [];
   @Input() gameId: number | undefined;
+  @Input() objectUrls?: Map<string, string>;
   @Input() disabled = false;
   @Output() remove = new EventEmitter<void>();
   @Output() fileUploaded = new EventEmitter<UploadedFile>();
 
   protected readonly HintType = HintType;
+  protected readonly AppEmoji = AppEmoji;
 
   isUploading = false;
+  /** "выбрать из загруженных" toggles the file/thumb picker dropdowns. */
+  showFileBrowser = false;
+  showThumbBrowser = false;
 
   constructor(
     private constructorService: ConstructorService,
@@ -122,11 +127,14 @@ export class HintEditorComponent {
           this.snackbar.error("Сервер вернул файл без идентификатора");
           return;
         }
+        this.objectUrls?.set(uploaded.guid, URL.createObjectURL(file));
         this.fileUploaded.emit(uploaded);
         if (target === "file") {
           this.hint.file_guid = uploaded.guid;
+          this.showFileBrowser = false;
         } else {
           this.hint.thumb_guid = uploaded.guid;
+          this.showThumbBrowser = false;
         }
         this.snackbar.success(`Файл загружен: ${uploaded.original_filename}${uploaded.extension}`);
       },
@@ -163,9 +171,35 @@ export class HintEditorComponent {
   }
 
   previewUrl(): string | undefined {
-    if (!this.hint.file_guid || this.gameId === undefined) {
+    const guid = this.hint.file_guid;
+    if (!guid) {
       return undefined;
     }
-    return this.http.getFileUrl(this.gameId, this.hint.file_guid);
+    const local = this.objectUrls?.get(guid);
+    if (local) {
+      return local;
+    }
+    if (this.gameId === undefined) {
+      return undefined;
+    }
+    return this.http.getFileUrl(this.gameId, guid);
+  }
+
+  toggleFileBrowser() {
+    this.showFileBrowser = !this.showFileBrowser;
+  }
+
+  toggleThumbBrowser() {
+    this.showThumbBrowser = !this.showThumbBrowser;
+  }
+
+  currentFileLabel(): string | undefined {
+    const f = this.files.find(file => file.guid === this.hint.file_guid);
+    return f ? this.fileLabel(f) : undefined;
+  }
+
+  currentThumbLabel(): string | undefined {
+    const f = this.files.find(file => file.guid === this.hint.thumb_guid);
+    return f ? this.fileLabel(f) : undefined;
   }
 }

--- a/src/app/constructor/hint-editor.component.ts
+++ b/src/app/constructor/hint-editor.component.ts
@@ -2,15 +2,21 @@ import {Component, EventEmitter, Input, Output} from "@angular/core";
 import {FormsModule} from "@angular/forms";
 import {HintType} from "../domain/game.models";
 import {
-  ALL_HINT_TYPES,
   CAPTION_ABOVE_HINT_TYPES,
   CAPTION_HINT_TYPES,
+  CONTENT_TYPE_LABELS,
   FILE_HINT_TYPES,
   HINT_TYPE_LABELS,
   HintPayload,
   THUMB_HINT_TYPES,
   UploadedFile,
 } from "./constructor.models";
+import {ConstructorService} from "./constructor.service";
+import {HttpAdapter} from "../http/http.adapter";
+import {SnackbarService} from "../snackbar/snackbar.service";
+import {CONTENT_TYPE_EMOJI, HINT_TYPE_EMOJI} from "../ui/emoji";
+
+type PreviewKind = "image" | "video" | "audio" | "none";
 
 @Component({
   selector: "app-hint-editor",
@@ -22,26 +28,35 @@ import {
 export class HintEditorComponent {
   @Input({required: true}) hint!: HintPayload;
   @Input() files: UploadedFile[] = [];
-  @Input() index = 0;
+  @Input() gameId: number | undefined;
+  @Input() disabled = false;
   @Output() remove = new EventEmitter<void>();
+  @Output() fileUploaded = new EventEmitter<UploadedFile>();
 
   protected readonly HintType = HintType;
-  protected readonly allTypes = ALL_HINT_TYPES;
-  protected readonly typeLabels = HINT_TYPE_LABELS;
 
-  onTypeChange() {
-    // Reset type-specific fields so we never send stale data for the new type.
-    const type = this.hint.type;
-    Object.keys(this.hint).forEach(key => {
-      if (key !== "type") {
-        delete (this.hint as any)[key];
-      }
-    });
-    this.hint.type = type;
+  isUploading = false;
+
+  constructor(
+    private constructorService: ConstructorService,
+    private http: HttpAdapter,
+    private snackbar: SnackbarService,
+  ) {
+  }
+
+  get typeEmoji(): string {
+    return HINT_TYPE_EMOJI[this.hint.type];
+  }
+
+  get typeLabel(): string {
+    return HINT_TYPE_LABELS[this.hint.type];
   }
 
   fileLabel(file: UploadedFile): string {
-    return `${file.original_filename}${file.extension || ""}`;
+    const name = `${file.original_filename}${file.extension || ""}`;
+    const contentType = file.content_type ? CONTENT_TYPE_LABELS[file.content_type] ?? file.content_type : undefined;
+    const emoji = file.content_type ? CONTENT_TYPE_EMOJI[file.content_type] ?? "" : "";
+    return contentType ? `${emoji} ${name} (${contentType})` : name;
   }
 
   needsFile(): boolean {
@@ -62,5 +77,67 @@ export class HintEditorComponent {
 
   onRemove() {
     this.remove.emit();
+  }
+
+  // ---------------------------------------------------------------------
+  // Upload (for an empty hint or to replace the current file)
+  // ---------------------------------------------------------------------
+
+  onUploadSelected(event: Event, target: "file" | "thumb") {
+    const input = event.target as HTMLInputElement;
+    const file = input.files?.[0];
+    if (!file || this.gameId === undefined) {
+      return;
+    }
+
+    this.isUploading = true;
+    this.constructorService.uploadFile(this.gameId, file).subscribe({
+      next: uploaded => {
+        this.isUploading = false;
+        input.value = "";
+        this.fileUploaded.emit(uploaded);
+        if (target === "file") {
+          this.hint.file_guid = uploaded.guid;
+        } else {
+          this.hint.thumb_guid = uploaded.guid;
+        }
+        this.snackbar.success(`Файл загружен: ${uploaded.original_filename}${uploaded.extension}`);
+      },
+      error: () => {
+        this.isUploading = false;
+        input.value = "";
+      },
+    });
+  }
+
+  // ---------------------------------------------------------------------
+  // Preview of the selected file
+  // ---------------------------------------------------------------------
+
+  previewKind(): PreviewKind {
+    if (!this.hint.file_guid) {
+      return "none";
+    }
+    switch (this.hint.type) {
+      case HintType.photo:
+      case HintType.sticker:
+        return "image";
+      case HintType.video:
+      case HintType.animation:
+      case HintType.video_note:
+        return "video";
+      case HintType.audio:
+      case HintType.voice:
+        return "audio";
+      default:
+        return "none";
+    }
+  }
+
+  previewUrl(): string | undefined {
+    if (!this.hint.file_guid || this.gameId === undefined) {
+      return undefined;
+    }
+    return this.http.getFileUrl(this.gameId, this.hint.file_guid);
   }
 }

--- a/src/app/constructor/hint-editor.component.ts
+++ b/src/app/constructor/hint-editor.component.ts
@@ -15,13 +15,14 @@ import {ConstructorService} from "./constructor.service";
 import {HttpAdapter} from "../http/http.adapter";
 import {SnackbarService} from "../snackbar/snackbar.service";
 import {CONTENT_TYPE_EMOJI, HINT_TYPE_EMOJI} from "../ui/emoji";
+import {ImageLightboxComponent} from "../ui/image-lightbox.component";
 
 type PreviewKind = "image" | "video" | "audio" | "none";
 
 @Component({
   selector: "app-hint-editor",
   standalone: true,
-  imports: [FormsModule],
+  imports: [FormsModule, ImageLightboxComponent],
   templateUrl: "./hint-editor.component.html",
   styleUrl: "./hint-editor.component.scss",
 })
@@ -52,8 +53,29 @@ export class HintEditorComponent {
     return HINT_TYPE_LABELS[this.hint.type];
   }
 
+  /** Single "lat, lon" field — matches what users paste from map apps. */
+  get coords(): string {
+    const lat = this.hint.latitude;
+    const lon = this.hint.longitude;
+    if (lat === undefined && lon === undefined) {
+      return "";
+    }
+    return `${lat ?? ""}, ${lon ?? ""}`;
+  }
+
+  set coords(value: string) {
+    const parts = value.split(/[,\s]+/).map(p => p.trim()).filter(Boolean);
+    const lat = parts[0] !== undefined ? Number(parts[0]) : NaN;
+    const lon = parts[1] !== undefined ? Number(parts[1]) : NaN;
+    this.hint.latitude = Number.isFinite(lat) ? lat : undefined;
+    this.hint.longitude = Number.isFinite(lon) ? lon : undefined;
+  }
+
   fileLabel(file: UploadedFile): string {
-    const name = `${file.original_filename}${file.extension || ""}`;
+    const hasName = file.original_filename && file.original_filename !== file.guid;
+    const name = hasName
+      ? `${file.original_filename}${file.extension || ""}`
+      : `файл ${file.guid.slice(0, 8)}…`;
     const contentType = file.content_type ? CONTENT_TYPE_LABELS[file.content_type] ?? file.content_type : undefined;
     const emoji = file.content_type ? CONTENT_TYPE_EMOJI[file.content_type] ?? "" : "";
     return contentType ? `${emoji} ${name} (${contentType})` : name;

--- a/src/app/constructor/hint-editor.component.ts
+++ b/src/app/constructor/hint-editor.component.ts
@@ -1,0 +1,66 @@
+import {Component, EventEmitter, Input, Output} from "@angular/core";
+import {FormsModule} from "@angular/forms";
+import {HintType} from "../domain/game.models";
+import {
+  ALL_HINT_TYPES,
+  CAPTION_ABOVE_HINT_TYPES,
+  CAPTION_HINT_TYPES,
+  FILE_HINT_TYPES,
+  HINT_TYPE_LABELS,
+  HintPayload,
+  THUMB_HINT_TYPES,
+  UploadedFile,
+} from "./constructor.models";
+
+@Component({
+  selector: "app-hint-editor",
+  standalone: true,
+  imports: [FormsModule],
+  templateUrl: "./hint-editor.component.html",
+  styleUrl: "./hint-editor.component.scss",
+})
+export class HintEditorComponent {
+  @Input({required: true}) hint!: HintPayload;
+  @Input() files: UploadedFile[] = [];
+  @Input() index = 0;
+  @Output() remove = new EventEmitter<void>();
+
+  protected readonly HintType = HintType;
+  protected readonly allTypes = ALL_HINT_TYPES;
+  protected readonly typeLabels = HINT_TYPE_LABELS;
+
+  onTypeChange() {
+    // Reset type-specific fields so we never send stale data for the new type.
+    const type = this.hint.type;
+    Object.keys(this.hint).forEach(key => {
+      if (key !== "type") {
+        delete (this.hint as any)[key];
+      }
+    });
+    this.hint.type = type;
+  }
+
+  fileLabel(file: UploadedFile): string {
+    return `${file.original_filename}${file.extension || ""}`;
+  }
+
+  needsFile(): boolean {
+    return FILE_HINT_TYPES.includes(this.hint.type);
+  }
+
+  needsThumb(): boolean {
+    return THUMB_HINT_TYPES.includes(this.hint.type);
+  }
+
+  needsCaption(): boolean {
+    return CAPTION_HINT_TYPES.includes(this.hint.type);
+  }
+
+  needsCaptionAbove(): boolean {
+    return CAPTION_ABOVE_HINT_TYPES.includes(this.hint.type);
+  }
+
+  onRemove() {
+    this.remove.emit();
+  }
+}

--- a/src/app/constructor/hint-editor.component.ts
+++ b/src/app/constructor/hint-editor.component.ts
@@ -10,6 +10,7 @@ import {
   HintPayload,
   THUMB_HINT_TYPES,
   UploadedFile,
+  describeError,
 } from "./constructor.models";
 import {ConstructorService} from "./constructor.service";
 import {HttpAdapter} from "../http/http.adapter";
@@ -117,6 +118,10 @@ export class HintEditorComponent {
       next: uploaded => {
         this.isUploading = false;
         input.value = "";
+        if (!uploaded || !uploaded.guid) {
+          this.snackbar.error("Сервер вернул файл без идентификатора");
+          return;
+        }
         this.fileUploaded.emit(uploaded);
         if (target === "file") {
           this.hint.file_guid = uploaded.guid;
@@ -125,9 +130,10 @@ export class HintEditorComponent {
         }
         this.snackbar.success(`Файл загружен: ${uploaded.original_filename}${uploaded.extension}`);
       },
-      error: () => {
+      error: err => {
         this.isUploading = false;
         input.value = "";
+        this.snackbar.error(`Не удалось загрузить файл: ${describeError(err)}`);
       },
     });
   }

--- a/src/app/constructor/hint-type-picker.component.html
+++ b/src/app/constructor/hint-type-picker.component.html
@@ -1,0 +1,11 @@
+<details class="picker" #menu>
+  <summary class="picker-button">{{ label }}</summary>
+  <div class="picker-menu">
+    @for (t of allTypes; track t) {
+      <button type="button" class="picker-item" (click)="pick(t)">
+        <span class="picker-emoji">{{ typeEmoji[t] }}</span>
+        <span>{{ typeLabels[t] }}</span>
+      </button>
+    }
+  </div>
+</details>

--- a/src/app/constructor/hint-type-picker.component.scss
+++ b/src/app/constructor/hint-type-picker.component.scss
@@ -1,0 +1,58 @@
+@use "../../styles/component-mixins" as cm;
+
+.picker {
+  position: relative;
+  display: inline-block;
+}
+
+.picker-button {
+  @include cm.button-base();
+  display: inline-block;
+  background: transparent;
+  border: 1px solid var(--app-border);
+  color: inherit;
+  white-space: nowrap;
+  list-style: none;
+  user-select: none;
+}
+
+.picker-button::-webkit-details-marker {
+  display: none;
+}
+
+.picker-menu {
+  position: absolute;
+  right: 0;
+  z-index: 20;
+  margin-top: 0.3rem;
+  min-width: 15rem;
+  @include cm.surface-card(10px, 0.3rem);
+  box-shadow: 0 10px 28px rgba(16, 24, 40, 0.18);
+  display: grid;
+  gap: 0.1rem;
+  max-height: 18rem;
+  overflow-y: auto;
+}
+
+.picker-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border: none;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  padding: 0.45rem 0.6rem;
+  border-radius: 8px;
+  cursor: pointer;
+  font-size: 0.9rem;
+}
+
+.picker-item:hover {
+  background: color-mix(in srgb, var(--app-surface) 70%, var(--app-accent));
+}
+
+.picker-emoji {
+  width: 1.4rem;
+  text-align: center;
+}

--- a/src/app/constructor/hint-type-picker.component.scss
+++ b/src/app/constructor/hint-type-picker.component.scss
@@ -22,10 +22,11 @@
 
 .picker-menu {
   position: absolute;
-  right: 0;
+  left: 0;
   z-index: 1100;
   margin-top: 0.3rem;
-  min-width: 15rem;
+  width: max-content;
+  min-width: 12rem;
   max-width: calc(100vw - 2rem);
   @include cm.surface-card(10px, 0.3rem);
   box-shadow: 0 10px 28px rgba(16, 24, 40, 0.18);
@@ -33,22 +34,6 @@
   gap: 0.1rem;
   max-height: 18rem;
   overflow-y: auto;
-}
-
-// On small screens anchor the menu as a bottom sheet so it can never run off
-// the side of the viewport regardless of where the trigger button sits.
-@media (max-width: 640px) {
-  .picker-menu {
-    position: fixed;
-    left: 0.75rem;
-    right: 0.75rem;
-    bottom: 0.75rem;
-    top: auto;
-    margin-top: 0;
-    min-width: 0;
-    max-width: none;
-    max-height: 60vh;
-  }
 }
 
 .picker-item {

--- a/src/app/constructor/hint-type-picker.component.scss
+++ b/src/app/constructor/hint-type-picker.component.scss
@@ -23,15 +23,32 @@
 .picker-menu {
   position: absolute;
   right: 0;
-  z-index: 20;
+  z-index: 1100;
   margin-top: 0.3rem;
   min-width: 15rem;
+  max-width: calc(100vw - 2rem);
   @include cm.surface-card(10px, 0.3rem);
   box-shadow: 0 10px 28px rgba(16, 24, 40, 0.18);
   display: grid;
   gap: 0.1rem;
   max-height: 18rem;
   overflow-y: auto;
+}
+
+// On small screens anchor the menu as a bottom sheet so it can never run off
+// the side of the viewport regardless of where the trigger button sits.
+@media (max-width: 640px) {
+  .picker-menu {
+    position: fixed;
+    left: 0.75rem;
+    right: 0.75rem;
+    bottom: 0.75rem;
+    top: auto;
+    margin-top: 0;
+    min-width: 0;
+    max-width: none;
+    max-height: 60vh;
+  }
 }
 
 .picker-item {

--- a/src/app/constructor/hint-type-picker.component.ts
+++ b/src/app/constructor/hint-type-picker.component.ts
@@ -1,6 +1,6 @@
 import {Component, ElementRef, EventEmitter, Input, Output, ViewChild} from "@angular/core";
 import {HintType} from "../domain/game.models";
-import {ALL_HINT_TYPES, HINT_TYPE_LABELS} from "./constructor.models";
+import {CREATABLE_HINT_TYPES, HINT_TYPE_LABELS} from "./constructor.models";
 import {HINT_TYPE_EMOJI} from "../ui/emoji";
 
 /**
@@ -21,7 +21,7 @@ export class HintTypePickerComponent {
 
   @ViewChild("menu") menuRef: ElementRef<HTMLDetailsElement> | undefined;
 
-  protected readonly allTypes = ALL_HINT_TYPES;
+  protected readonly allTypes = CREATABLE_HINT_TYPES;
   protected readonly typeLabels = HINT_TYPE_LABELS;
   protected readonly typeEmoji = HINT_TYPE_EMOJI;
 

--- a/src/app/constructor/hint-type-picker.component.ts
+++ b/src/app/constructor/hint-type-picker.component.ts
@@ -1,0 +1,34 @@
+import {Component, ElementRef, EventEmitter, Input, Output, ViewChild} from "@angular/core";
+import {HintType} from "../domain/game.models";
+import {ALL_HINT_TYPES, HINT_TYPE_LABELS} from "./constructor.models";
+import {HINT_TYPE_EMOJI} from "../ui/emoji";
+
+/**
+ * "+ Подсказка" button that opens a menu of hint part types.
+ * The type is chosen once, at creation time — existing hint parts
+ * keep their type and cannot be switched.
+ */
+@Component({
+  selector: "app-hint-type-picker",
+  standalone: true,
+  imports: [],
+  templateUrl: "./hint-type-picker.component.html",
+  styleUrl: "./hint-type-picker.component.scss",
+})
+export class HintTypePickerComponent {
+  @Input() label = "+ Подсказка";
+  @Output() picked = new EventEmitter<HintType>();
+
+  @ViewChild("menu") menuRef: ElementRef<HTMLDetailsElement> | undefined;
+
+  protected readonly allTypes = ALL_HINT_TYPES;
+  protected readonly typeLabels = HINT_TYPE_LABELS;
+  protected readonly typeEmoji = HINT_TYPE_EMOJI;
+
+  pick(type: HintType) {
+    this.picked.emit(type);
+    if (this.menuRef) {
+      this.menuRef.nativeElement.open = false;
+    }
+  }
+}

--- a/src/app/effects.part/effects.part.component.ts
+++ b/src/app/effects.part/effects.part.component.ts
@@ -2,6 +2,7 @@ import {Component, Input} from '@angular/core';
 import {EffectLike, Effects, HintPart} from "../domain/game.models";
 import {HintPartComponent} from "../hint.part/hint.part.component";
 import {HttpAdapter} from "../http/http.adapter";
+import {AppEmoji} from "../ui/emoji";
 
 @Component({
   selector: 'app-effects-part',
@@ -28,22 +29,22 @@ export class EffectsPartComponent {
     const bonusMinutes = typeof effect.bonus_minutes === 'number' ? effect.bonus_minutes : 0;
 
     if (bonusMinutes > 0) {
-      tags.push(`💰бонус ${bonusMinutes} мин.`);
+      tags.push(`${AppEmoji.bonus}бонус ${bonusMinutes} мин.`);
     } else if (bonusMinutes < 0) {
-      tags.push(`💸штраф ${-bonusMinutes} мин.`);
+      tags.push(`${AppEmoji.penalty}штраф ${-bonusMinutes} мин.`);
     }
 
     if (effect.level_up) {
       if (effect.next_level) {
-        tags.push(`🔀переход на ${effect.next_level}`);
+        tags.push(`${AppEmoji.jump}переход на ${effect.next_level}`);
       } else {
-        tags.push('✅переход на следующий уровень');
+        tags.push(`${AppEmoji.levelUp}переход на следующий уровень`);
       }
     }
 
     const hintsCount = Effects.hints(effect).length;
     if (hintsCount > 0) {
-      tags.push(`💡бонусные подсказки (${hintsCount}):`);
+      tags.push(`${AppEmoji.bonusHint}бонусные подсказки (${hintsCount}):`);
     }
 
     return tags;

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -132,7 +132,7 @@
             @for (event of getCurrentLevelEvents(); track event.id) {
               <li class="event-entry">
                 <strong>{{ toLocal(event.at) }}</strong>
-                @if(event.key) {<span>🔑{{event.key}}</span>}
+                @if(event.key) {<span>{{AppEmoji.key}}{{event.key}}</span>}
                 @if(event.is_timer) {<span>🕑</span>}
                 @if (hasEventVisibleEffects(event)) {
                   <button
@@ -171,7 +171,7 @@
               @for (event of getPreviousLevelEvents(); track event.id) {
                 <li class="event-entry">
                   <strong>{{ toLocal(event.at) }}</strong>
-                  @if(event.key) {<span>🔑{{event.key}}</span>}
+                  @if(event.key) {<span>{{AppEmoji.key}}{{event.key}}</span>}
                   @if(event.is_timer) {<span>🕑</span>}
                   @if (hasEventVisibleEffects(event)) {
                     <button

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -22,6 +22,7 @@ import {EffectsPartComponent} from "../effects.part/effects.part.component";
 import {UserService} from "../auth/user.service";
 import {GameScenarioPartComponent} from "../game_scenario.part/game_scenario.part.component";
 import {PushToggleComponent} from "../push/push-toggle.component";
+import {AppEmoji} from "../ui/emoji";
 
 @Component({
   selector: 'app-game-play',
@@ -38,6 +39,7 @@ import {PushToggleComponent} from "../push/push-toggle.component";
   styleUrl: './game_play.component.scss'
 })
 export class GamePlayComponent implements OnInit, OnDestroy {
+  protected readonly AppEmoji = AppEmoji;
   activeGame: ActiveGame | undefined;
   countdownToStart: string | undefined;
   keyText: string = "";
@@ -312,21 +314,21 @@ export class GamePlayComponent implements OnInit, OnDestroy {
 
     const bonusMinutes = typeof effect.bonus_minutes === 'number' ? effect.bonus_minutes : 0;
     if (bonusMinutes > 0) {
-      tags.push(`+💰бонус ${bonusMinutes} мин.`);
+      tags.push(`+${AppEmoji.bonus}бонус ${bonusMinutes} мин.`);
     } else if (bonusMinutes < 0) {
-      tags.push(`-💸штраф ${-bonusMinutes} мин.`);
+      tags.push(`-${AppEmoji.penalty}штраф ${-bonusMinutes} мин.`);
     }
     if (effect.level_up) {
       if (effect.next_level) {
-        tags.push(`🔀переход на ${effect.next_level}`);
+        tags.push(`${AppEmoji.jump}переход на ${effect.next_level}`);
       } else {
-        tags.push('✅переход на следующий уровень');
+        tags.push(`${AppEmoji.levelUp}переход на следующий уровень`);
       }
     }
 
     const hintsCount = Effects.hints(effect).length;
     if (hintsCount > 0) {
-      tags.push(`💡бонусные подсказки: ${hintsCount}`);
+      tags.push(`${AppEmoji.bonusHint}бонусные подсказки: ${hintsCount}`);
     }
 
     return tags;

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -35,7 +35,7 @@
       <a routerLink="/games/running" routerLinkActive="active" class="nav-link" (click)="onNavClick('/games/running', $event)">Текущая игра</a>
     }
     @if (isAuthenticated() && canBeAuthor()) {
-      <a routerLink="/games/constructor" routerLinkActive="active" class="nav-link" (click)="onNavClick('/games/constructor', $event)">Конструктор</a>
+      <a routerLink="/games/constructor" routerLinkActive="active" class="nav-link" (click)="onNavClick('/games/constructor', $event)">Черновики</a>
     }
   </nav>
 
@@ -103,7 +103,7 @@
     <a routerLink="/profile" class="mobile-link" (click)="onNavClick('/profile', $event)">Профиль</a>
   }
   @if (isAuthenticated() && canBeAuthor()) {
-    <a routerLink="/games/constructor" class="mobile-link" (click)="onNavClick('/games/constructor', $event)">Конструктор</a>
+    <a routerLink="/games/constructor" class="mobile-link" (click)="onNavClick('/games/constructor', $event)">Черновики</a>
   }
   @if (hasCurrentGameTab()) {
     <a routerLink="/games/running" class="mobile-link" (click)="onNavClick('/games/running', $event)">Текущая игра</a>

--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -34,6 +34,9 @@
     @if (hasCurrentGameTab()) {
       <a routerLink="/games/running" routerLinkActive="active" class="nav-link" (click)="onNavClick('/games/running', $event)">Текущая игра</a>
     }
+    @if (isAuthenticated() && canBeAuthor()) {
+      <a routerLink="/games/constructor" routerLinkActive="active" class="nav-link" (click)="onNavClick('/games/constructor', $event)">Конструктор</a>
+    }
   </nav>
 
 
@@ -98,6 +101,9 @@
   <a routerLink="/games" class="mobile-link" (click)="onNavClick('/games', $event)">Прошедшие игры</a>
   @if (isAuthenticated()) {
     <a routerLink="/profile" class="mobile-link" (click)="onNavClick('/profile', $event)">Профиль</a>
+  }
+  @if (isAuthenticated() && canBeAuthor()) {
+    <a routerLink="/games/constructor" class="mobile-link" (click)="onNavClick('/games/constructor', $event)">Конструктор</a>
   }
   @if (hasCurrentGameTab()) {
     <a routerLink="/games/running" class="mobile-link" (click)="onNavClick('/games/running', $event)">Текущая игра</a>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -113,6 +113,10 @@ export class HeaderComponent implements OnInit, OnDestroy {
     return this.userService.isUserLoaded();
   }
 
+  canBeAuthor() {
+    return this.userService.canBeAuthor();
+  }
+
   async ngOnInit() {
     this.selectedThemeMode = this.themeService.getMode();
     this.gamesService.getActiveGame().subscribe(game => {

--- a/src/app/http/http.adapter.ts
+++ b/src/app/http/http.adapter.ts
@@ -73,6 +73,14 @@ export class HttpAdapter {
     return `${this.config.cdnUrl}/games/${gameId}/files/${fileId}`
   }
 
+  postCdnForm<T>(url: string, formData: FormData): Observable<T> {
+    return this.http.post<T>(
+      this.config.cdnUrl + url,
+      formData,
+      {withCredentials: true},
+    );
+  }
+
   private shouldBlockProtectedRequest(url: string): boolean {
     if (!this.authStateService.isUnauthenticated()) {
       return false;
@@ -83,6 +91,7 @@ export class HttpAdapter {
 
   private isProtectedUrl(url: string): boolean {
     return /^\/games\/\d+$/.test(url)
+      || /^\/games\/my(\/.*)?$/.test(url)
       || /^\/games\/\d+\/keys$/.test(url)
       || /^\/games\/\d+\/stat$/.test(url)
       || /^\/games\/\d+\/files\/.+$/.test(url)

--- a/src/app/ui/emoji.ts
+++ b/src/app/ui/emoji.ts
@@ -1,0 +1,61 @@
+import {HintType} from "../domain/game.models";
+
+/**
+ * Central registry of every emoji used in the UI.
+ *
+ * Do not hardcode emoji in templates/components — always reference this enum.
+ * The names (not the glyphs) are the stable contract: when we later replace
+ * emoji with SVG icons, this is the single place to swap (e.g. by mapping the
+ * same names to `MatIcon` svg ids).
+ */
+export enum AppEmoji {
+  // game mechanics
+  key = "🔑",
+  timer = "⏱️",
+  autoFinish = "⏰",
+  bonusHint = "💡",
+  bonus = "💰",
+  penalty = "💸",
+  jump = "🔀",
+  levelUp = "✅",
+  level = "🧩",
+  // files
+  files = "📁",
+  upload = "📤",
+  // hint part types
+  text = "📝",
+  gps = "📍",
+  venue = "🏛️",
+  photo = "📷",
+  audio = "🎵",
+  video = "🎬",
+  document = "📄",
+  animation = "🎞️",
+  voice = "🎤",
+  videoNote = "📹",
+  contact = "👤",
+  sticker = "🖼️",
+}
+
+export const HINT_TYPE_EMOJI: Record<HintType, AppEmoji> = {
+  [HintType.text]: AppEmoji.text,
+  [HintType.gps]: AppEmoji.gps,
+  [HintType.venue]: AppEmoji.venue,
+  [HintType.photo]: AppEmoji.photo,
+  [HintType.audio]: AppEmoji.audio,
+  [HintType.video]: AppEmoji.video,
+  [HintType.document]: AppEmoji.document,
+  [HintType.animation]: AppEmoji.animation,
+  [HintType.voice]: AppEmoji.voice,
+  [HintType.video_note]: AppEmoji.videoNote,
+  [HintType.contact]: AppEmoji.contact,
+  [HintType.sticker]: AppEmoji.sticker,
+};
+
+/** Emoji for the CDN `content_type` of an uploaded file. */
+export const CONTENT_TYPE_EMOJI: Record<string, AppEmoji> = {
+  photo: AppEmoji.photo,
+  video: AppEmoji.video,
+  audio: AppEmoji.audio,
+  document: AppEmoji.document,
+};

--- a/src/app/ui/emoji.ts
+++ b/src/app/ui/emoji.ts
@@ -19,6 +19,8 @@ export enum AppEmoji {
   jump = "🔀",
   levelUp = "✅",
   level = "🧩",
+  reorder = "↕️",
+  remove = "🗑️",
   // files
   files = "📁",
   upload = "📤",

--- a/src/app/ui/emoji.ts
+++ b/src/app/ui/emoji.ts
@@ -19,7 +19,6 @@ export enum AppEmoji {
   jump = "🔀",
   levelUp = "✅",
   level = "🧩",
-  reorder = "↕️",
   remove = "🗑️",
   // files
   files = "📁",

--- a/src/app/ui/image-lightbox.component.html
+++ b/src/app/ui/image-lightbox.component.html
@@ -1,0 +1,7 @@
+<img class="thumb" [src]="src" [alt]="alt" loading="lazy" (click)="open()" />
+
+@if (isOpen) {
+  <div class="lightbox-overlay" (click)="close()">
+    <img class="lightbox-full" [src]="src" [alt]="alt" />
+  </div>
+}

--- a/src/app/ui/image-lightbox.component.scss
+++ b/src/app/ui/image-lightbox.component.scss
@@ -1,0 +1,28 @@
+.thumb {
+  max-width: 240px;
+  max-height: 180px;
+  border-radius: 8px;
+  border: 1px solid var(--app-border);
+  object-fit: contain;
+  cursor: zoom-in;
+  display: block;
+}
+
+.lightbox-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  cursor: zoom-out;
+}
+
+.lightbox-full {
+  max-width: 100%;
+  max-height: 100%;
+  border-radius: 8px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+}

--- a/src/app/ui/image-lightbox.component.ts
+++ b/src/app/ui/image-lightbox.component.ts
@@ -1,0 +1,32 @@
+import {Component, HostListener, Input} from "@angular/core";
+
+/**
+ * Image thumbnail that opens a full-size overlay on click.
+ * Used for media previews in the constructor.
+ */
+@Component({
+  selector: "app-image-lightbox",
+  standalone: true,
+  imports: [],
+  templateUrl: "./image-lightbox.component.html",
+  styleUrl: "./image-lightbox.component.scss",
+})
+export class ImageLightboxComponent {
+  @Input({required: true}) src!: string;
+  @Input() alt = "превью";
+
+  isOpen = false;
+
+  open() {
+    this.isOpen = true;
+  }
+
+  close() {
+    this.isOpen = false;
+  }
+
+  @HostListener("document:keydown.escape")
+  onEscape() {
+    this.close();
+  }
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -103,6 +103,23 @@ pre {
   }
 }
 
+/* CDK drag-drop: the drag preview is attached to <body>, so style it globally */
+.cdk-drag-preview {
+  background: var(--app-surface);
+  color: var(--app-text);
+  border: 1px solid var(--app-border);
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(16, 24, 40, 0.25);
+}
+
+.cdk-drag-placeholder {
+  opacity: 0.4;
+}
+
+.cdk-drag-animating {
+  transition: transform 0.2s cubic-bezier(0, 0, 0.2, 1);
+}
+
 .snackbar-success .mdc-snackbar__surface {
   background-color: #2e7d32 !important;
 }


### PR DESCRIPTION
## Summary

Adds a **games constructor** UI so authors can create and manage games, implementing the *Shvatka — Games Constructor API Contract*.

### What's included

- **"Конструктор" section** (`/games/constructor`) — lists the current author's drafts (`GET /games/my`) and creates new ones (`POST /games/my`). The nav link is shown to authenticated users and hidden when the backend says `can_be_author === false`.
- **Game editor** (`/games/constructor/:id`) covering the full scenario model from §2:
  - game name
  - levels (add / remove / reorder)
  - time hints (incl. enforced `time: 0`) with all **12 hint types** (text, gps, venue, photo, audio, video, document, animation, voice, video_note, contact, sticker), including captions, thumbnails and `link_preview` round-tripping
  - conditions: `WIN_KEY`, `EFFECTS_KEY`, `EFFECTS_TIMER` with full **Effects** (bonus minutes, level-up, next_level routing, bonus hints)
  - **file uploads** (`POST /cdn/games/{id}/files`) with a per-game file list referenced from hints
  - planned **start time** (`PUT …/start_at`) and **status** transitions (`PUT …/status`: open waivers / complete)
- **Client-side validation** mirroring the contract invariants (§3): time-0 presence, unique times, single WIN_KEY, single winning timer, winning-timer ordering, key format (`SH…`/`СХ…`), unique keys/effect ids, `next_level` existence, file-guid presence, etc. Errors are surfaced before save; the server still enforces everything.
- `ConstructorService` wrapping the `/games/my` endpoints plus a `postCdnForm` helper on `HttpAdapter` for multipart uploads.

### Notes / limitations

- Scenarios round-trip in the contract's `snake_case` shape, so load → edit → save works without key conversion.
- The `files` array is rebuilt from uploads during the session. If `GET /games/my/{id}` does not return a top-level `files` array, file metadata (`original_filename`/`extension`) for previously uploaded media can only be reconstructed best-effort from referenced guids — re-uploading is the safe path. If the backend returns `files`, it is used directly.
- Conventions match the existing codebase: standalone Angular components, template-driven forms with `ngModel`, `HttpAdapter`, `SnackbarService`, and the shared SCSS mixins / theme variables. Hardcoded Russian copy, consistent with the rest of the app.

### Testing

- `npm run build` passes (only a pre-existing-style SCSS budget warning, consistent with other components).

https://claude.ai/code/session_01QvaoEk1sJ4FqFP36DePfVC

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvaoEk1sJ4FqFP36DePfVC)_