### PR TITLE
Add team waiver publishing on current game page

### DIFF
--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -240,6 +240,13 @@
     @if (getCountdownToStart()) {
       <p class="waivers-countdown">До старта: {{ getCountdownToStart() }}</p>
     }
+    @if (isGettingWaivers() && canManageWaivers()) {
+      <div class="waivers-manage-bar">
+        <button type="button" (click)="openWaiverModal()">
+          Подать вейверы команды
+        </button>
+      </div>
+    }
     <ul class="waivers-teams">
       @for (team of getCurrentWaivers()!.teams; track team.id) {
         <li class="waivers-team-card">
@@ -261,6 +268,60 @@
         </li>
       }
     </ul>
+  </div>
+}
+
+@if (isWaiverModalOpen) {
+  <div class="waiver-modal-backdrop" (click)="closeWaiverModal()">
+    <div class="waiver-modal" (click)="$event.stopPropagation()">
+      <button
+        type="button"
+        class="icon-close waiver-modal-close"
+        (click)="closeWaiverModal()"
+        [disabled]="isPublishingWaivers"
+        aria-label="Закрыть"
+      >✕</button>
+      <h3 class="waiver-modal-title">Подать вейверы команды</h3>
+      <p class="waiver-modal-hint">Отметьте игроков, которые будут играть.</p>
+
+      @if (getMyTeamMembers().length > 0) {
+        <ul class="waiver-modal-players">
+          @for (member of getMyTeamMembers(); track member.id) {
+            <li class="waiver-modal-player">
+              <label class="waiver-toggle-label">
+                <input
+                  type="checkbox"
+                  [checked]="isWaiverPlayerSelected(member)"
+                  [disabled]="isPublishingWaivers"
+                  (change)="toggleWaiverPlayer(member, $any($event).target.checked)"
+                />
+                @if (member.emoji) {
+                  <span class="waiver-player-emoji" aria-hidden="true">{{ member.emoji }}</span>
+                }
+                <span class="waiver-player-name">{{ getMemberDisplayName(member) }}</span>
+                <span class="waiver-player-status">{{ isWaiverPlayerSelected(member) ? 'Играет' : 'Нет вейвера' }}</span>
+              </label>
+            </li>
+          }
+        </ul>
+      } @else {
+        <p class="status-message">Список игроков команды недоступен.</p>
+      }
+
+      <div class="waiver-modal-actions">
+        <button type="button" (click)="publishWaivers()" [disabled]="isPublishingWaivers">
+          @if (isPublishingWaivers) {
+            <span class="button-loader"></span>
+            Отправка...
+          } @else {
+            Опубликовать ({{ getSelectedWaiverCount() }})
+          }
+        </button>
+        <button type="button" class="btn-ghost" (click)="closeWaiverModal()" [disabled]="isPublishingWaivers">
+          Отмена
+        </button>
+      </div>
+    </div>
   </div>
 }
 

--- a/src/app/game_play/game_play.component.scss
+++ b/src/app/game_play/game_play.component.scss
@@ -335,6 +335,101 @@ td {
   color: var(--tg-theme-hint-color, #6b7280);
 }
 
+.waivers-manage-bar {
+  display: flex;
+  justify-content: center;
+  margin: 0 0 1rem;
+}
+
+.waiver-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  z-index: 1000;
+}
+
+.waiver-modal {
+  position: relative;
+  width: 100%;
+  max-width: 480px;
+  max-height: 85vh;
+  overflow-y: auto;
+  background: var(--app-surface, #fff);
+  border-radius: 12px;
+  padding: 1.1rem 1rem 1rem;
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.3);
+  text-align: left;
+}
+
+.waiver-modal-close {
+  position: absolute;
+  top: 0.55rem;
+  right: 0.55rem;
+  background: #f3f4f6;
+  color: #111827;
+}
+
+.waiver-modal-title {
+  margin: 0 0 0.25rem;
+}
+
+.waiver-modal-hint {
+  margin: 0 0 0.9rem;
+  color: var(--tg-theme-hint-color, #6b7280);
+}
+
+.waiver-modal-players {
+  margin: 0 0 1rem;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.waiver-modal-player {
+  list-style: none;
+}
+
+.waiver-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 8px;
+  padding: 0.5rem 0.65rem;
+  cursor: pointer;
+}
+
+.waiver-toggle-label input {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.waiver-player-name {
+  font-weight: 600;
+}
+
+.waiver-player-status {
+  margin-left: auto;
+  font-size: 0.8rem;
+  color: var(--tg-theme-hint-color, #6b7280);
+}
+
+.waiver-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.waiver-modal-actions .btn-ghost {
+  background: #e5e7eb;
+  color: #111827;
+}
+
 .spy-panel {
   margin-top: 1rem;
 }

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -9,7 +9,8 @@ import {
   WaiversTeam,
   WaiverEntry,
   Played,
-  OrganizerDto
+  OrganizerDto,
+  WaiverInput
 } from "./game_play.service";
 import {HttpAdapter} from "../http/http.adapter";
 import {HintPartComponent} from "../hint.part/hint.part.component";
@@ -23,6 +24,8 @@ import {UserService} from "../auth/user.service";
 import {GameScenarioPartComponent} from "../game_scenario.part/game_scenario.part.component";
 import {PushToggleComponent} from "../push/push-toggle.component";
 import {AppEmoji} from "../ui/emoji";
+import {SnackbarService} from "../snackbar/snackbar.service";
+import {TeamMember} from "../team/team.models";
 
 @Component({
   selector: 'app-game-play',
@@ -49,6 +52,9 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   isSubmitting = false;
   authorScenario: FullGame | undefined;
   isAuthorScenarioLoading = false;
+  isWaiverModalOpen = false;
+  isPublishingWaivers = false;
+  waiverSelection: Record<number, boolean> = {};
   private activeGameSubscription: Subscription | undefined;
   private countdownInterval: ReturnType<typeof setInterval> | undefined;
   private keyResultTimer: ReturnType<typeof setTimeout> | undefined;
@@ -65,6 +71,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     private gameService: GamePlayService,
     private http: HttpAdapter,
     private userService: UserService,
+    private snackbar: SnackbarService,
     ) {
   }
 
@@ -193,6 +200,100 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     const teamCaptainId = myRole.team?.captain?.id;
     const myOrgId = myRole.org?.player.id;
     return entry.player.id === teamCaptainId || entry.player.id === myOrgId;
+  }
+
+  isGettingWaivers(): boolean {
+    return this.activeGame?.status === "getting_waivers";
+  }
+
+  getMyTeamMembers(): TeamMember[] {
+    return this.gameService.getMyTeamMembers() ?? [];
+  }
+
+  getMemberDisplayName(member: TeamMember): string {
+    return member.username ?? `#${member.id}`;
+  }
+
+  canManageWaivers(): boolean {
+    const role = this.gameService.getMyRole();
+    if (!role?.team) {
+      return false;
+    }
+
+    const myId = this.userService.getMe()?.id;
+    if (myId !== undefined && role.team.captain?.id === myId) {
+      return true;
+    }
+
+    const member = this.getMyTeamMembers().find(m => m.id === myId);
+    return !!member?.permissions.can_manage_waivers;
+  }
+
+  openWaiverModal(): void {
+    const currentWaiverIds = this.getMyTeamCurrentWaiverIds();
+    const selection: Record<number, boolean> = {};
+    for (const member of this.getMyTeamMembers()) {
+      selection[member.id] = currentWaiverIds.has(member.id);
+    }
+    this.waiverSelection = selection;
+    this.isWaiverModalOpen = true;
+  }
+
+  closeWaiverModal(): void {
+    if (this.isPublishingWaivers) {
+      return;
+    }
+    this.isWaiverModalOpen = false;
+  }
+
+  isWaiverPlayerSelected(member: TeamMember): boolean {
+    return !!this.waiverSelection[member.id];
+  }
+
+  toggleWaiverPlayer(member: TeamMember, selected: boolean): void {
+    this.waiverSelection = {...this.waiverSelection, [member.id]: selected};
+  }
+
+  getSelectedWaiverCount(): number {
+    return this.getMyTeamMembers().filter(m => this.waiverSelection[m.id]).length;
+  }
+
+  publishWaivers(): void {
+    if (this.isPublishingWaivers) {
+      return;
+    }
+
+    const waivers: WaiverInput[] = this.getMyTeamMembers()
+      .filter(member => this.waiverSelection[member.id])
+      .map(member => ({player_id: member.id, played: Played.yes}));
+
+    this.isPublishingWaivers = true;
+    this.gameService.replaceMyTeamWaivers(waivers)
+      .pipe(finalize(() => {
+        this.isPublishingWaivers = false;
+      }))
+      .subscribe({
+        next: () => {
+          this.snackbar.success("Вейверы команды опубликованы");
+          this.isWaiverModalOpen = false;
+          this.gameService.loadHints();
+        },
+        error: error => {
+          const description = error?.error?.description;
+          this.snackbar.error(description || "Не удалось опубликовать вейверы");
+        }
+      });
+  }
+
+  private getMyTeamCurrentWaiverIds(): Set<number> {
+    const teamId = this.gameService.getMyRole()?.team?.id;
+    const waiversMap = this.getCurrentWaivers()?.waivers;
+    if (teamId === undefined || !waiversMap) {
+      return new Set<number>();
+    }
+
+    const entries = waiversMap[String(teamId)] ?? [];
+    return new Set<number>(entries.map(entry => entry.player.id));
   }
 
   canOpenSpyTab(): boolean {

--- a/src/app/game_play/game_play.service.ts
+++ b/src/app/game_play/game_play.service.ts
@@ -5,6 +5,8 @@ import {SnackbarService} from "../snackbar/snackbar.service";
 import {Effect, Effects, GameStat, KeyTime, Keys, TimeHint} from "../domain/game.models";
 import {Observable, tap} from "rxjs";
 import {ActiveGame, GamesService} from "../games/games.service";
+import {TeamService} from "../team/team.service";
+import {TeamMember} from "../team/team.models";
 
 export type TypedKeyLog = KeyTime & {
   effects?: Effect[];
@@ -85,6 +87,27 @@ export enum Played {
   not_allowed = "not_allowed",
 }
 
+export interface WaiverInput {
+  player_id: number;
+  played?: Played;
+}
+
+export class TeamWaiverEntry {
+  constructor(
+    public player: WaiverPlayer,
+    public played: Played,
+  ) {
+  }
+}
+
+export class TeamWaivers {
+  constructor(
+    public team: WaiversTeam,
+    public players: TeamWaiverEntry[],
+  ) {
+  }
+}
+
 export class RolePlayer {
   constructor(
     public id: number,
@@ -130,6 +153,8 @@ export class MyRoleDto {
 export class GamePlayService {
   private currentHints: CurrentHints | undefined;
   private currentWaivers: CurrentWaivers | undefined;
+  private myTeamMembers: TeamMember[] | undefined;
+  private myTeamMembersTeamId: number | undefined;
   private myRole: MyRoleDto | undefined;
   private myRoleGameId: number | undefined;
   private myRoleCacheUntil: number | undefined;
@@ -147,6 +172,7 @@ export class GamePlayService {
     private http: HttpAdapter,
     private snackbar: SnackbarService,
     private gamesService: GamesService,
+    private teamService: TeamService,
   ) {
   }
 
@@ -157,6 +183,8 @@ export class GamePlayService {
       if (!game) {
         this.currentHints = undefined;
         this.currentWaivers = undefined;
+        this.myTeamMembers = undefined;
+        this.myTeamMembersTeamId = undefined;
         this.myRole = undefined;
         this.spyGameId = undefined;
         this.spyKeys = undefined;
@@ -166,7 +194,14 @@ export class GamePlayService {
       }
 
       if (game.status === "getting_waivers") {
-        this.loadMyRole(game);
+        this.loadMyRole(game, false, role => {
+          if (role?.team) {
+            this.loadMyTeamMembers(role.team.id);
+          } else {
+            this.myTeamMembers = undefined;
+            this.myTeamMembersTeamId = undefined;
+          }
+        });
         this.loadWaivers();
         return;
       }
@@ -378,6 +413,32 @@ export class GamePlayService {
 
   getCurrentWaivers(): CurrentWaivers | undefined {
     return this.currentWaivers;
+  }
+
+  getMyTeamMembers(): TeamMember[] | undefined {
+    return this.myTeamMembers;
+  }
+
+  replaceMyTeamWaivers(waivers: WaiverInput[]): Observable<TeamWaivers> {
+    return this.http.put<TeamWaivers>(`/waivers/game/current`, {waivers});
+  }
+
+  private loadMyTeamMembers(teamId: number) {
+    if (this.myTeamMembersTeamId === teamId && this.myTeamMembers) {
+      return;
+    }
+
+    this.teamService.getTeamPlayers(teamId)
+      .subscribe({
+        next: res => {
+          this.myTeamMembers = res.items;
+          this.myTeamMembersTeamId = teamId;
+        },
+        error: () => {
+          this.myTeamMembers = undefined;
+          this.myTeamMembersTeamId = undefined;
+        }
+      });
   }
 
   getMyRole(): MyRoleDto | undefined {


### PR DESCRIPTION
## Summary

Adds the ability to publish a team's waivers from the current game page, as described in the Waivers REST API UI contract.

- A **"Подать вейверы команды"** button appears in the waivers panel, only during the `getting_waivers` game status and only for the **captain** or a team player with the `can_manage_waivers` permission.
- Pressing it opens a modal listing **all** of the team's players (the captain/permission holder is also a player and can include themselves), each with a single toggle: *Нет вейвера* ↔ *Играет*.
- Toggles are pre-populated from the team's current `played = yes` waivers.
- On publish, only the **selected** players are sent as `{ player_id, played: "yes" }` to `PUT /waivers/game/current`. Unselected players are **omitted entirely** (never sent as `no`); the backend's full-replace semantics then remove their waivers.
- On success the waivers list is reloaded; domain error `description` text from `422` responses is surfaced via the snackbar.

## Implementation notes

- `GamePlayService` now loads the caller's team members (via `TeamService.getTeamPlayers`) during the `getting_waivers` flow and exposes `replaceMyTeamWaivers()`.
- `GamePlayComponent` gains the modal state, permission check (`canManageWaivers`), selection toggles, and publish logic.
- Permission check mirrors the existing captain-bridge convention: captain by `team.captain.id`, otherwise the member's `can_manage_waivers` flag.

## Testing

- `ng build` passes (existing SCSS budget warnings only, consistent with sibling components).

https://claude.ai/code/session_01CVBn9h1KqhWYG3YcjqCEFv

---
_Generated by [Claude Code](https://claude.ai/code/session_01CVBn9h1KqhWYG3YcjqCEFv)_