### PR TITLE
Highlight current player (not captain) in waivers list

### DIFF
--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -192,14 +192,8 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   }
 
   isCurrentUserWaiver(entry: WaiverEntry): boolean {
-    const myRole = this.gameService.getMyRole();
-    if (!myRole) {
-      return false;
-    }
-
-    const teamCaptainId = myRole.team?.captain?.id;
-    const myOrgId = myRole.org?.player.id;
-    return entry.player.id === teamCaptainId || entry.player.id === myOrgId;
+    const myId = this.userService.getMe()?.id;
+    return myId !== undefined && entry.player.id === myId;
   }
 
   isGettingWaivers(): boolean {


### PR DESCRIPTION
## Problem

`isCurrentUserWaiver` was comparing each waiver entry against the team **captain's** id (and the org player id), so the waiver list highlighted the captain for every team member rather than the viewer themselves — despite the function name being about the current user.

## Fix

Compare each entry's player id against the current user's own id (`userService.getMe()?.id`), which already shares the same id space as the role/waiver player ids (see `canManageWaivers`, which compares `captain?.id === getMe()?.id`).

```ts
isCurrentUserWaiver(entry: WaiverEntry): boolean {
  const myId = this.userService.getMe()?.id;
  return myId !== undefined && entry.player.id === myId;
}
```

https://claude.ai/code/session_01HUcFoHs4UZMw8NUB6zLBK8

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUcFoHs4UZMw8NUB6zLBK8)_