### PR TITLE
Hide disable push button in game play view

### DIFF
--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -1,5 +1,5 @@
 <div class="push-toggle-bar">
-  <app-push-toggle></app-push-toggle>
+  <app-push-toggle [allowDisable]="false"></app-push-toggle>
 </div>
 
 @if (isLoading()) {

--- a/src/app/push/push-toggle.component.html
+++ b/src/app/push/push-toggle.component.html
@@ -15,20 +15,22 @@
     </span>
   }
   @case ('granted') {
-    <button
-      type="button"
-      class="push-button push-button-on"
-      [disabled]="push.busy()"
-      (click)="disable()"
-    >
-      <svg class="push-icon" viewBox="0 0 24 24" aria-hidden="true">
-        <path fill="currentColor"
-              d="M12 22a2.5 2.5 0 0 0 2.45-2h-4.9A2.5 2.5 0 0 0 12 22m8-5v-1l-1.5-1.5V10a6.5 6.5 0 0 0-5-6.32V3a1.5 1.5 0 0 0-3 0v.68A6.5 6.5 0 0 0 5.5 10v4.5L4 16v1z"/>
-        <path fill="currentColor"
-              d="m20.7 19.3-16-16-1.4 1.4 16 16z" opacity="0.9"/>
-      </svg>
-      {{ push.busy() ? 'Отключаем…' : 'Отключить уведомления' }}
-    </button>
+    @if (allowDisable) {
+      <button
+        type="button"
+        class="push-button push-button-on"
+        [disabled]="push.busy()"
+        (click)="disable()"
+      >
+        <svg class="push-icon" viewBox="0 0 24 24" aria-hidden="true">
+          <path fill="currentColor"
+                d="M12 22a2.5 2.5 0 0 0 2.45-2h-4.9A2.5 2.5 0 0 0 12 22m8-5v-1l-1.5-1.5V10a6.5 6.5 0 0 0-5-6.32V3a1.5 1.5 0 0 0-3 0v.68A6.5 6.5 0 0 0 5.5 10v4.5L4 16v1z"/>
+          <path fill="currentColor"
+                d="m20.7 19.3-16-16-1.4 1.4 16 16z" opacity="0.9"/>
+        </svg>
+        {{ push.busy() ? 'Отключаем…' : 'Отключить уведомления' }}
+      </button>
+    }
   }
   @default {
     <button

--- a/src/app/push/push-toggle.component.ts
+++ b/src/app/push/push-toggle.component.ts
@@ -1,4 +1,4 @@
-import {Component} from '@angular/core';
+import {Component, Input} from '@angular/core';
 import {PushService} from './push.service';
 
 @Component({
@@ -9,6 +9,8 @@ import {PushService} from './push.service';
   styleUrl: './push-toggle.component.scss',
 })
 export class PushToggleComponent {
+  @Input() allowDisable = true;
+
   constructor(public push: PushService) {
   }
 


### PR DESCRIPTION
## Summary

In the current game play view, only the **enable push** button is now shown. The **disable push** button is hidden there. The profile page keeps both actions (enable and disable) as before.

## Changes

- Added an `allowDisable` input (default `true`) to `PushToggleComponent`.
- In `push-toggle.component.html`, the "Отключить уведомления" (disable) button is only rendered when `allowDisable` is `true`.
- `game_play.component.html` uses `<app-push-toggle [allowDisable]="false">`, so only the enable button appears during a game.
- `profile.component.html` is unchanged and uses the default, showing both enable and disable.

## Verification

- `npm run build` succeeds (only pre-existing SCSS budget warnings).

https://claude.ai/code/session_01DE1PKu5fZvdjejjsGcSesF

---
_Generated by [Claude Code](https://claude.ai/code/session_01DE1PKu5fZvdjejjsGcSesF)_