### PR TITLE
Capture errors site-wide into debug log

### DIFF
--- a/src/app/debug/debug-log.service.ts
+++ b/src/app/debug/debug-log.service.ts
@@ -1,0 +1,74 @@
+import {Inject, Injectable} from "@angular/core";
+import {DOCUMENT} from "@angular/common";
+
+const STORAGE_KEY = "debug-log";
+const MAX_LINES = 40;
+
+/**
+ * Keeps a rolling, best-effort debug log in session storage so it can be
+ * inspected after something goes wrong (e.g. on mobile / Telegram WebApp where
+ * there is no devtools console).
+ */
+@Injectable({
+  providedIn: "root",
+})
+export class DebugLogService {
+  private readonly window: (Window & typeof globalThis) | undefined;
+
+  constructor(@Inject(DOCUMENT) document: any) {
+    this.window = document?.defaultView ?? undefined;
+  }
+
+  info(message: string): void {
+    const timestamp = new Date().toISOString();
+    const line = `[debug-info][${timestamp}] ${message}`;
+    console.info(line);
+    this.append(line);
+  }
+
+  /**
+   * Logs an error together with meta info about what we were trying to do.
+   */
+  error(action: string, error: any): void {
+    this.info(`error: ${action} ${this.describeError(error)}`);
+  }
+
+  private describeError(error: any): string {
+    if (error == null) {
+      return "(no error object)";
+    }
+    const status = typeof error?.status === "number" ? error.status : "unknown";
+    const url = error?.url ? ` url=${this.extractPath(error.url)}` : "";
+    const backend = error?.error;
+    const description =
+      (backend && typeof backend === "object"
+        ? backend.description ?? backend.text ?? backend.type
+        : undefined) ??
+      error?.message ??
+      String(error);
+    return `status=${status}${url} message=${description}`;
+  }
+
+  private extractPath(url: string): string {
+    try {
+      return new URL(url).pathname;
+    } catch {
+      return url;
+    }
+  }
+
+  private append(line: string): void {
+    if (!this.window) {
+      return;
+    }
+    try {
+      const existing = this.window.sessionStorage.getItem(STORAGE_KEY);
+      const currentLines = existing ? existing.split("\n").filter(Boolean) : [];
+      currentLines.push(line);
+      const tail = currentLines.slice(-MAX_LINES);
+      this.window.sessionStorage.setItem(STORAGE_KEY, tail.join("\n"));
+    } catch {
+      // Storage may be unavailable (private mode, quota). Ignore — logging is best-effort.
+    }
+  }
+}

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -25,6 +25,7 @@ import {GameScenarioPartComponent} from "../game_scenario.part/game_scenario.par
 import {PushToggleComponent} from "../push/push-toggle.component";
 import {AppEmoji} from "../ui/emoji";
 import {SnackbarService} from "../snackbar/snackbar.service";
+import {DebugLogService} from "../debug/debug-log.service";
 import {TeamMember} from "../team/team.models";
 
 @Component({
@@ -72,6 +73,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     private http: HttpAdapter,
     private userService: UserService,
     private snackbar: SnackbarService,
+    private debugLog: DebugLogService,
     ) {
   }
 
@@ -273,6 +275,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
           this.gameService.loadHints();
         },
         error: error => {
+          this.debugLog.error("publish team waivers", error);
           const description = error?.error?.description;
           this.snackbar.error(description || "Не удалось опубликовать вейверы");
         }
@@ -394,7 +397,8 @@ export class GamePlayComponent implements OnInit, OnDestroy {
           this.startResultTimer();
           this.keyText = "";
         },
-        error: () => {
+        error: error => {
+          this.debugLog.error("submit key", error);
           this.keySubmitError = "Не удалось отправить ключ";
         }
       });
@@ -751,7 +755,8 @@ export class GamePlayComponent implements OnInit, OnDestroy {
         next: fullGame => {
           this.authorScenario = fullGame;
         },
-        error: () => {
+        error: error => {
+          this.debugLog.error("load author scenario", error);
           this.authorScenario = undefined;
         }
       });
@@ -784,14 +789,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   }
 
   private logDebugInfo(message: string) {
-    const line = `[game-play][${new Date().toISOString()}] ${message}`;
-    console.info(line);
-
-    const key = 'debug-log';
-    const existing = window.sessionStorage.getItem(key);
-    const currentLines = existing ? existing.split('\n').filter(Boolean) : [];
-    currentLines.push(line);
-    window.sessionStorage.setItem(key, currentLines.slice(-80).join('\n'));
+    this.debugLog.info(`game-play: ${message}`);
   }
 
   private stopVisibilityWatcher() {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -9,6 +9,7 @@ import {MatIcon} from "@angular/material/icon";
 import {ActiveGame, GamesService} from "../games/games.service";
 import {THEME_MODES, ThemeMode, ThemeService} from "../theme/theme.service";
 import {PushService} from "../push/push.service";
+import {DebugLogService} from "../debug/debug-log.service";
 
 type CountdownUnit = "days" | "hours" | "minutes" | "seconds";
 
@@ -51,6 +52,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
     private router: Router,
     private themeService: ThemeService,
     private pushService: PushService,
+    private debugLog: DebugLogService,
   ) {
     this.window = this._document.defaultView;
     this.tg = (this.window as any)?.Telegram;
@@ -327,26 +329,11 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   private logDebugError(action: string, error: any) {
-    const status = typeof error?.status === "number" ? error.status : "unknown";
-    const description = error?.error?.description ?? error?.message ?? String(error);
-    this.logDebugInfo(`error: ${action} status=${status} message=${description}`);
+    this.debugLog.error(action, error);
   }
 
   private logDebugInfo(message: string) {
-    const timestamp = new Date().toISOString();
-    const line = `[debug-info][${timestamp}] ${message}`;
-    console.info(line);
-
-    if (!this.window) {
-      return;
-    }
-
-    const key = "debug-log";
-    const existing = this.window.sessionStorage.getItem(key);
-    const currentLines = existing ? existing.split("\n").filter(Boolean) : [];
-    currentLines.push(line);
-    const tail = currentLines.slice(-40);
-    this.window.sessionStorage.setItem(key, tail.join("\n"));
+    this.debugLog.info(message);
   }
 
   countdownUnitLabel(unit: CountdownUnit): string {

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -63,9 +63,18 @@ export class HeaderComponent implements OnInit, OnDestroy {
   }
 
   logout() {
-    this.pushService.onLogout().finally(() => {
-      this.authService.logout().subscribe(() => this.userService.clearUser());
-    });
+    this.logDebugInfo("attempt: logout");
+    this.pushService.onLogout()
+      .catch(error => this.logDebugError("push onLogout before logout", error))
+      .finally(() => {
+        this.authService.logout().subscribe({
+          next: () => {
+            this.userService.clearUser();
+            this.logDebugInfo("success: logout");
+          },
+          error: error => this.logDebugError("logout", error),
+        });
+      });
     this.closeMobileMenu();
   }
 
@@ -119,10 +128,13 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   async ngOnInit() {
     this.selectedThemeMode = this.themeService.getMode();
-    this.gamesService.getActiveGame().subscribe(game => {
-      this.activeGame = game;
-      this.countdown = this.getCountdown();
-      this.setupCountdownTicker();
+    this.gamesService.getActiveGame().subscribe({
+      next: game => {
+        this.activeGame = game;
+        this.countdown = this.getCountdown();
+        this.setupCountdownTicker();
+      },
+      error: error => this.logDebugError("load active game", error),
     });
 
 
@@ -130,16 +142,24 @@ export class HeaderComponent implements OnInit, OnDestroy {
       this.logDebugInfo(`attempt: authenticate blocking webapp (initDataLength=${this.tgWa.initData.length})`);
       const telegramAuthResult = await this.authenticateTelegramWebApp(this.tgWa);
       if (telegramAuthResult) {
-        await this.userService.loadMe();
-        this.pushService.refresh();
-        this.tgWa?.ready?.();
+        try {
+          await this.userService.loadMe();
+          this.pushService.refresh();
+          this.tgWa?.ready?.();
+        } catch (error) {
+          this.logDebugError("load me after telegram webapp auth", error);
+        }
         return;
       }
     } else {
       this.logDebugInfo("skip: blocking webapp is missing initData");
     }
 
-    await this.userService.loadMe();
+    try {
+      await this.userService.loadMe();
+    } catch (error) {
+      this.logDebugError("load me", error);
+    }
   }
 
   hasActiveGame() {
@@ -295,8 +315,7 @@ export class HeaderComponent implements OnInit, OnDestroy {
             resolve(true);
           },
           error: (error) => {
-            const status = typeof error?.status === "number" ? error.status : "unknown";
-            this.logDebugInfo(`failed: authenticateWebApp status=${status}`);
+            this.logDebugError("authenticateWebApp", error);
             resolve(false);
           },
         });
@@ -305,6 +324,12 @@ export class HeaderComponent implements OnInit, OnDestroy {
 
   private stringifyForDebug(payload: any): string {
     return "disabled debug"
+  }
+
+  private logDebugError(action: string, error: any) {
+    const status = typeof error?.status === "number" ? error.status : "unknown";
+    const description = error?.error?.description ?? error?.message ?? String(error);
+    this.logDebugInfo(`error: ${action} status=${status} message=${description}`);
   }
 
   private logDebugInfo(message: string) {

--- a/src/app/http/error.handler.ts
+++ b/src/app/http/error.handler.ts
@@ -2,6 +2,7 @@ import {ErrorHandler, Injectable, NgZone} from "@angular/core";
 import {HttpErrorResponse} from "@angular/common/http";
 import {AuthService} from "../auth/auth.service";
 import {SnackbarService} from "../snackbar/snackbar.service";
+import {DebugLogService} from "../debug/debug-log.service";
 
 @Injectable({
   providedIn: 'root'
@@ -14,9 +15,11 @@ export class GlobalErrorHandler implements ErrorHandler {
     private snackbar: SnackbarService,
     private _zone: NgZone,
     private authService: AuthService,
+    private debugLog: DebugLogService,
   ) { }
 
   handleError(error: any): void {
+    this.logToDebug(error);
     this._zone.run(() => {
       if (!(error instanceof HttpErrorResponse)) {
         console.error(error);
@@ -49,6 +52,21 @@ export class GlobalErrorHandler implements ErrorHandler {
         );
       }
     });
+  }
+
+  private logToDebug(error: any): void {
+    try {
+      if (error instanceof HttpErrorResponse) {
+        const method = (error as any)?.method;
+        const action = `http request${method ? ` ${method}` : ""}`;
+        this.debugLog.error(action, error);
+      } else {
+        const name = error?.name || error?.constructor?.name || "Error";
+        this.debugLog.error(`uncaught ${name}`, error);
+      }
+    } catch {
+      // Never let debug logging break the real error handling.
+    }
   }
 
   private formatUnknownHttpError(error: HttpErrorResponse): string {


### PR DESCRIPTION
## Summary

The app keeps a rolling, best-effort debug log in session storage (under the `debug-log` key) so failures can be inspected after the fact — especially on mobile / Telegram WebApp where there's no devtools console. Previously only a few hand-picked spots in the header wrote to it. This PR makes error capture **site-wide**.

## Changes

- **New `DebugLogService`** (`src/app/debug/debug-log.service.ts`) — owns the rolling log. `error(action, error)` records *what we were trying to do* plus meta info: status, request path, and message/backend description. Storage access is wrapped so logging can never throw.
- **`GlobalErrorHandler`** — the central funnel for all uncaught and HTTP errors now logs every error through the service with meta info (action, status, url, message). This is what makes capture site-wide.
- **Header component** — delegates to the shared service and logs locally-handled errors: active game load, logout (push unsubscribe + logout), user load, Telegram WebApp auth.
- **Game-play component** — delegates to the shared service and logs its previously-swallowed `error:` handlers: publish team waivers, submit key, load author scenario.

## Notes

- Errors caught in local `subscribe({ error })` handlers don't reach the global `ErrorHandler`, so those are logged explicitly at the call site; everything else is caught globally.
- Storage remains `sessionStorage` (unchanged from existing behaviour).

https://claude.ai/code/session_01Byj6XUhJr5W4TPQiACG1eF