### PR TITLE
Allow organizers with view_scenario to see current game scenario

### DIFF
--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -380,7 +380,7 @@
   </div>
 }
 
-@if (isCurrentUserGameAuthor()) {
+@if (canViewScenario()) {
   <details class="author-scenario-spoiler">
     <summary class="game-scn-spoiler">Сценарий текущей игры</summary>
     @if (isAuthorScenarioLoading) {

--- a/src/app/game_play/game_play.component.ts
+++ b/src/app/game_play/game_play.component.ts
@@ -52,6 +52,8 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   isSubmitting = false;
   authorScenario: FullGame | undefined;
   isAuthorScenarioLoading = false;
+  private loadedScenarioGameId: number | undefined;
+  private myRoleListenerUnsubscribe: (() => void) | undefined;
   isWaiverModalOpen = false;
   isPublishingWaivers = false;
   waiverSelection: Record<number, boolean> = {};
@@ -81,6 +83,9 @@ export class GamePlayComponent implements OnInit, OnDestroy {
       this.startCountdownTicker();
       this.loadAuthorScenario(game);
     });
+    this.myRoleListenerUnsubscribe = this.gameService.onMyRoleResolved(() => {
+      this.loadAuthorScenario(this.activeGame);
+    });
     this.gameService.loadHints();
     this.startAutoRefreshTicker();
     this.startVisibilityWatcher();
@@ -88,6 +93,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.clearResultTimer();
+    this.myRoleListenerUnsubscribe?.();
     this.activeGameSubscription?.unsubscribe();
     this.clearCountdownTicker();
     this.clearAutoRefreshTicker();
@@ -162,8 +168,17 @@ export class GamePlayComponent implements OnInit, OnDestroy {
     return myId !== undefined && authorId !== undefined && myId === authorId;
   }
 
+  canViewScenario(): boolean {
+    if (this.isCurrentUserGameAuthor()) {
+      return true;
+    }
+
+    const org = this.gameService.getMyRole()?.org;
+    return !!org && !org.deleted && org.view_scenario;
+  }
+
   shouldShowAuthorScenario(): boolean {
-    return this.isCurrentUserGameAuthor() && !!this.authorScenario;
+    return this.canViewScenario() && !!this.authorScenario;
   }
 
   getCountdownToStart(): string | undefined {
@@ -735,13 +750,18 @@ export class GamePlayComponent implements OnInit, OnDestroy {
   }
 
   private loadAuthorScenario(game: ActiveGame | undefined) {
-    this.authorScenario = undefined;
-    this.isAuthorScenarioLoading = false;
-
-    if (!game || !this.isCurrentUserGameAuthor()) {
+    if (!game || !this.canViewScenario()) {
+      this.authorScenario = undefined;
+      this.isAuthorScenarioLoading = false;
+      this.loadedScenarioGameId = undefined;
       return;
     }
 
+    if (this.isAuthorScenarioLoading || this.loadedScenarioGameId === game.id) {
+      return;
+    }
+
+    this.loadedScenarioGameId = game.id;
     this.isAuthorScenarioLoading = true;
     this.http.get<FullGame>(`/games/${game.id}`)
       .pipe(finalize(() => {
@@ -753,6 +773,7 @@ export class GamePlayComponent implements OnInit, OnDestroy {
         },
         error: () => {
           this.authorScenario = undefined;
+          this.loadedScenarioGameId = undefined;
         }
       });
   }

--- a/src/app/game_play/game_play.service.ts
+++ b/src/app/game_play/game_play.service.ts
@@ -133,6 +133,7 @@ export class OrganizerDto {
     public can_spy: boolean,
     public can_see_log_keys: boolean,
     public can_validate_waivers: boolean,
+    public view_scenario: boolean,
     public deleted: boolean,
   ) {
   }
@@ -167,6 +168,7 @@ export class GamePlayService {
   private isSpyStatLoading = false;
   private isHintsLoading = false;
   private authRequired = false;
+  private myRoleListeners: ((role: MyRoleDto | undefined) => void)[] = [];
 
   constructor(
     private http: HttpAdapter,
@@ -277,6 +279,7 @@ export class GamePlayService {
 
     if (cacheValid) {
       this.maybeLoadSpyData(game.id, this.myRole);
+      this.notifyMyRoleResolved(this.myRole);
       onLoaded?.(this.myRole);
       return;
     }
@@ -288,6 +291,7 @@ export class GamePlayService {
           this.myRoleGameId = game.id;
           this.myRoleCacheUntil = this.resolveRoleCacheUntil(game);
           this.maybeLoadSpyData(game.id, role);
+          this.notifyMyRoleResolved(role);
           onLoaded?.(role);
         },
         error: error => {
@@ -296,6 +300,7 @@ export class GamePlayService {
             this.myRoleGameId = undefined;
             this.myRoleCacheUntil = undefined;
             this.authRequired = true;
+            this.notifyMyRoleResolved(undefined);
             onLoaded?.(undefined);
             return;
           }
@@ -443,6 +448,19 @@ export class GamePlayService {
 
   getMyRole(): MyRoleDto | undefined {
     return this.myRole;
+  }
+
+  onMyRoleResolved(listener: (role: MyRoleDto | undefined) => void): () => void {
+    this.myRoleListeners.push(listener);
+    return () => {
+      this.myRoleListeners = this.myRoleListeners.filter(l => l !== listener);
+    };
+  }
+
+  private notifyMyRoleResolved(role: MyRoleDto | undefined): void {
+    for (const listener of this.myRoleListeners) {
+      listener(role);
+    }
   }
 
   getSpyKeys(): Keys | undefined {


### PR DESCRIPTION
## Summary

Organizers now have a `view_scenario` permission. This change lets organizers who have that permission view the **current game** scenario in the game-play view, the same way it has been shown to the game author until now.

## Changes

- **`OrganizerDto`**: add a `view_scenario: boolean` flag (populated from `GET /games/active/me`).
- **`canViewScenario()`** (new): returns true for the game author, or for an organizer whose role is not deleted and has `view_scenario`.
- The scenario spoiler (`Сценарий текущей игры`), its loading state, and `loadAuthorScenario()` are now gated on `canViewScenario()` instead of the author-only check.
- **Timing fix**: the organizer role (`myRole`) loads asynchronously, after the active game is resolved. The component now re-attempts the scenario load once the role resolves (via a new `onMyRoleResolved` listener on `GamePlayService`), and `loadAuthorScenario()` is made idempotent (tracks the loaded game id) so the author path isn't re-fetched. The listener is unsubscribed in `ngOnDestroy`.

## Notes

- Requires the backend to include `view_scenario` in the organizer DTO returned by `GET /games/active/me`. Existing payloads without the field simply evaluate as falsy (no scenario shown), so this is backward compatible.
- `ng build` passes (only pre-existing SCSS budget warnings).

https://claude.ai/code/session_01USTnhDnS6q3NnYXbuQrYQV

---
_Generated by [Claude Code](https://claude.ai/code/session_01USTnhDnS6q3NnYXbuQrYQV)_