### PR TITLE
ci: build :dev Docker tag for feature branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,14 @@ name: ShvatkaUIBuild
 
 on:
   push:
-    branches: [ master, test ]
+    branches:
+      - master
+      - test
+      - 'claude/**'
+      - 'codex/**'
+      - 'feature/**'
+      - 'tech/**'
+      - 'fix/**'
     tags: ["*.*.*"]
 
 jobs:
@@ -18,10 +25,20 @@ jobs:
           echo "VCS_HASH=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           echo "COMMIT_AT=$(git show -s --format=%cI ${GITHUB_SHA})" >> "$GITHUB_OUTPUT"
           echo "VCS_NAME=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+      - name: Set Docker tag
+        id: docker_tag
+        run: |
+          if [[ "$GITHUB_REF_TYPE" == "tag" ]]; then
+            echo "tag=$GITHUB_REF_NAME" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_REF_NAME" == "master" ]]; then
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=dev" >> "$GITHUB_OUTPUT"
+          fi
       - uses: mr-smithers-excellent/docker-build-push@v6.2
         with:
           image: bomzheg/shvatka-ui
-          addLatest: true
+          tags: ${{ steps.docker_tag.outputs.tag }}
           registry: docker.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds branch triggers for `claude/**`, `codex/**`, `feature/**`, `tech/**`, `fix/**`
- Builds Docker image with `:dev` tag for those branches
- Master still publishes `:latest`; version tags still publish the tag name
- Removed `addLatest: true` in favour of explicit tag computation via a new step

## Test plan

- [ ] Push to a `feature/` branch → Docker Hub gets `bomzheg/shvatka-ui:dev`
- [ ] Push to `master` → Docker Hub gets `bomzheg/shvatka-ui:latest`
- [ ] Push a version tag (e.g. `1.2.3`) → Docker Hub gets `bomzheg/shvatka-ui:1.2.3`

https://claude.ai/code/session_016zbVqRaUsbCE5HYrKv94we

---
_Generated by [Claude Code](https://claude.ai/code/session_016zbVqRaUsbCE5HYrKv94we)_