### PR TITLE
Move side panel user profile and logout to bottom line

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -105,8 +105,6 @@
       <mat-icon aria-hidden="true" [svgIcon]="AppIcon.close"/>
     </button>
   </div>
-  <div class="mobile-auth">
-
   <div class="theme-picker mobile-theme-picker">
     <div class="theme-toggle" role="group" [attr.aria-label]="'Тема'">
       <button
@@ -146,20 +144,6 @@
     </div>
   </div>
 
-    @if (isAuthenticated()) {
-      <div class="mobile-user-row">
-        <a routerLink="/profile" class="mobile-profile-link" (click)="onNavClick('/profile', $event)">
-          <svg class="nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>
-          <span class="mobile-username">{{ getMe()?.name_mention }}</span>
-        </a>
-        <button class="mobile-logout-btn" type="button" (click)="logout()" aria-label="Выйти">
-          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z"/></svg>
-        </button>
-      </div>
-    } @else {
-      <button class="solid-button" type="button" (click)="openLoginForm()">Войти</button>
-    }
-  </div>
   @if (hasCurrentGameTab()) {
     <a routerLink="/games/running" class="mobile-link mobile-link--active-game" routerLinkActive="active" (click)="onNavClick('/games/running', $event)">
       <svg class="nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M8 5v14l11-7z"/></svg>
@@ -182,6 +166,23 @@
       <span>Команда</span>
     </a>
   }
+
+  <div class="mobile-footer">
+    @if (isAuthenticated()) {
+      <div class="mobile-user-row">
+        <a routerLink="/profile" class="mobile-profile-link" (click)="onNavClick('/profile', $event)">
+          <svg class="nav-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg>
+          <span class="mobile-username">{{ getMe()?.name_mention }}</span>
+        </a>
+        <button class="mobile-logout-btn" type="button" (click)="logout()">
+          <span>Выйти</span>
+          <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M17 7l-1.41 1.41L18.17 11H8v2h10.17l-2.58 2.58L17 17l5-5zM4 5h8V3H4c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h8v-2H4V5z"/></svg>
+        </button>
+      </div>
+    } @else {
+      <button class="solid-button" type="button" (click)="openLoginForm()">Войти</button>
+    }
+  </div>
 </aside>
 
 <app-auth/>

--- a/src/app/header/header.component.scss
+++ b/src/app/header/header.component.scss
@@ -254,8 +254,10 @@
     }
   }
 
-  .mobile-auth {
-    margin-top: 0;
+  .mobile-footer {
+    margin-top: auto;
+    padding-top: 0.75rem;
+    border-top: 1px solid var(--app-border);
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
@@ -264,6 +266,7 @@
   .mobile-user-row {
     display: flex;
     align-items: center;
+    justify-content: space-between;
     gap: 0.5rem;
   }
 
@@ -298,13 +301,15 @@
     flex-shrink: 0;
     display: inline-flex;
     align-items: center;
-    justify-content: center;
+    gap: 0.5rem;
     background: transparent;
     border: none;
     border-radius: 6px;
-    padding: 0.4rem;
+    padding: 0.4rem 0.5rem;
     cursor: pointer;
-    color: var(--app-muted-text);
+    font-weight: 600;
+    font-size: 1.05rem;
+    color: var(--app-text);
 
     svg {
       width: 1.25rem;


### PR DESCRIPTION
## Summary

Reworks the mobile side panel (`app-header`) so the user profile and the **Выйти** (logout) action sit on a single line pinned to the **bottom** of the panel, matching the requested design.

### Changes
- Moved the user/auth block out of the top of the panel (it previously sat right under the theme toggle) into a new `.mobile-footer` that is pushed to the bottom via `margin-top: auto`, with a divider on top.
- The footer row shows the account icon + username on the left and a **Выйти** button (text + exit icon) on the right.
- The theme toggle stays at the top, with **no "Тема" label added**, as requested.
- The unauthenticated state shows the **Войти** button in the same bottom footer.

### Verification
- `ng build` completes successfully (only pre-existing SCSS budget warnings).

https://claude.ai/code/session_01MWsPavrd783gdKhFZ4mZ5c

---
_Generated by [Claude Code](https://claude.ai/code/session_01MWsPavrd783gdKhFZ4mZ5c)_