### PR TITLE
Show org "view scenario" permission in role panel

### DIFF
--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -233,6 +233,11 @@
             } @else {
               <p><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.cancel"/>Не могу смотреть какая команда на каком уровне</p>
             }
+            @if (getMyOrg()?.view_scenario) {
+              <p><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.check"/>Могу смотреть сценарий</p>
+            } @else {
+              <p><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.cancel"/>Не могу смотреть сценарий</p>
+            }
           }
         }
       </div>

--- a/src/app/game_play/game_play.component.html
+++ b/src/app/game_play/game_play.component.html
@@ -224,19 +224,19 @@
           } @else {
             <p><strong>Я организатор:</strong></p>
             @if (getMyOrg()?.can_see_log_keys) {
-              <p><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.check"/>Могу смотреть лог ключей</p>
+              <p><mat-icon class="app-icon-inline app-icon-success" [svgIcon]="AppIcon.check"/>Могу смотреть лог ключей</p>
             } @else {
-              <p><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.cancel"/>Не могу смотреть лог ключей</p>
+              <p><mat-icon class="app-icon-inline app-icon-danger" [svgIcon]="AppIcon.cancel"/>Не могу смотреть лог ключей</p>
             }
             @if (getMyOrg()?.can_spy) {
-              <p><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.check"/>Могу смотреть какая команда на каком уровне</p>
+              <p><mat-icon class="app-icon-inline app-icon-success" [svgIcon]="AppIcon.check"/>Могу смотреть какая команда на каком уровне</p>
             } @else {
-              <p><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.cancel"/>Не могу смотреть какая команда на каком уровне</p>
+              <p><mat-icon class="app-icon-inline app-icon-danger" [svgIcon]="AppIcon.cancel"/>Не могу смотреть какая команда на каком уровне</p>
             }
             @if (getMyOrg()?.view_scenario) {
-              <p><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.check"/>Могу смотреть сценарий</p>
+              <p><mat-icon class="app-icon-inline app-icon-success" [svgIcon]="AppIcon.check"/>Могу смотреть сценарий</p>
             } @else {
-              <p><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.cancel"/>Не могу смотреть сценарий</p>
+              <p><mat-icon class="app-icon-inline app-icon-danger" [svgIcon]="AppIcon.cancel"/>Не могу смотреть сценарий</p>
             }
           }
         }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -123,6 +123,15 @@ mat-icon.app-icon-inline svg {
   display: block;
 }
 
+/* Status icon colors (fill follows currentColor) */
+mat-icon.app-icon-success {
+  color: #2e7d32;
+}
+
+mat-icon.app-icon-danger {
+  color: #c62828;
+}
+
 /* CDK drag-drop: the drag preview is attached to <body>, so style it globally */
 .cdk-drag-preview {
   background: var(--app-surface);


### PR DESCRIPTION
## Summary

Organizers gained an additional permission — viewing the game scenario (`view_scenario`). This permission was already present on `OrganizerDto` and used by `canViewScenario()`, but it wasn't displayed in the "Я организатор" section of the game play role panel.

This adds a line for it alongside the existing "лог ключей" and "какая команда на каком уровне" permissions:
- ✓ Могу смотреть сценарий / ✗ Не могу смотреть сценарий

## Changes
- `src/app/game_play/game_play.component.html`: render the `view_scenario` org permission with the same check/cancel icon pattern as the other permissions.

https://claude.ai/code/session_01XYth6CYTybadVJ9CKJxjo5

---
_Generated by [Claude Code](https://claude.ai/code/session_01XYth6CYTybadVJ9CKJxjo5)_