### PR TITLE
Manage organizers in the game draft editor

### DIFF
--- a/src/app/constructor/constructor.service.ts
+++ b/src/app/constructor/constructor.service.ts
@@ -6,6 +6,11 @@ import {environment} from "../../environments/environment";
 import {Page} from "../games/games.service";
 import {FullGame} from "../domain/game.models";
 import {MyGame, ScenarioPayload, UploadedFile} from "./constructor.models";
+import {GameOrganizer, OrgPermissionKey, OrgPlayer} from "./organizers.models";
+
+interface ItemsResponse<T> {
+  items: T[];
+}
 
 @Injectable({
   providedIn: "root",
@@ -53,5 +58,52 @@ export class ConstructorService {
       formData,
       {withCredentials: true},
     );
+  }
+
+  // -------------------------------------------------------------------------
+  // Organizers (Game Organizers API)
+  // -------------------------------------------------------------------------
+
+  /** List the organizers of a game (primary first, then secondary incl. deleted). */
+  listOrganizers(gameId: number): Observable<Page<GameOrganizer>> {
+    return this.http.get<Page<GameOrganizer>>(`/games/${gameId}/organizers`);
+  }
+
+  /** Add a player as a new secondary organizer (all permissions start false). */
+  addOrganizer(gameId: number, playerId: number): Observable<GameOrganizer> {
+    return this.http.post<GameOrganizer>(`/games/${gameId}/organizers`, {player_id: playerId});
+  }
+
+  /** Soft-delete a secondary organizer (the org is passed in the body, not path). */
+  deleteOrganizer(gameId: number, orgId: number): Observable<GameOrganizer> {
+    return this.httpClient.request<GameOrganizer>(
+      "DELETE",
+      `${environment.apiUrl}/games/${gameId}/organizers`,
+      {
+        withCredentials: true,
+        headers: {"Content-Type": "application/json"},
+        body: {org_id: orgId},
+        responseType: "json",
+      },
+    );
+  }
+
+  /** Set a single permission of a secondary organizer to an explicit value. */
+  setOrganizerPermission(
+    gameId: number,
+    orgId: number,
+    permission: OrgPermissionKey,
+    value: boolean,
+  ): Observable<GameOrganizer> {
+    return this.http.put<GameOrganizer>(
+      `/games/${gameId}/organizers/${orgId}`,
+      {permission, value},
+    );
+  }
+
+  /** Search players by username — used to pick a new organizer to invite. */
+  searchPlayers(query: string): Observable<ItemsResponse<OrgPlayer>> {
+    const qs = new URLSearchParams({username: query}).toString();
+    return this.http.get<ItemsResponse<OrgPlayer>>(`/users?${qs}`);
   }
 }

--- a/src/app/constructor/game-editor.component.html
+++ b/src/app/constructor/game-editor.component.html
@@ -40,6 +40,9 @@
       <input id="gameName" type="text" [(ngModel)]="name" [disabled]="!isEditable" />
     </div>
 
+    <!-- Organizers -->
+    <app-organizers-editor [gameId]="gameId"></app-organizers-editor>
+
     <!-- Levels -->
     <div class="block">
       <div class="block-head">

--- a/src/app/constructor/game-editor.component.ts
+++ b/src/app/constructor/game-editor.component.ts
@@ -7,6 +7,7 @@ import {ConstructorService} from "./constructor.service";
 import {HintEditorComponent} from "./hint-editor.component";
 import {HintTypePickerComponent} from "./hint-type-picker.component";
 import {EffectsEditorComponent} from "./effects-editor.component";
+import {OrganizersEditorComponent} from "./organizers-editor.component";
 import {ImageLightboxComponent} from "../ui/image-lightbox.component";
 import {FullGame, HintType, Level, ScenarioConditionType} from "../domain/game.models";
 import {
@@ -69,6 +70,7 @@ type FilePreviewKind = "image" | "video" | "audio" | "none";
     HintEditorComponent,
     HintTypePickerComponent,
     EffectsEditorComponent,
+    OrganizersEditorComponent,
     ImageLightboxComponent,
     MatIcon,
   ],

--- a/src/app/constructor/organizers-editor.component.html
+++ b/src/app/constructor/organizers-editor.component.html
@@ -1,0 +1,114 @@
+<div class="block organizers-block">
+  <div class="block-head">
+    <h2><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.contact"/> Организаторы</h2>
+  </div>
+  <p class="hint-note">Автор всегда имеет все права и не может быть удалён. Дополнительным
+    организаторам можно выдавать отдельные права.</p>
+
+  @if (isLoading && organizers.length === 0) {
+    <div class="loading-state" aria-live="polite">
+      <span class="loading-spinner"></span>
+      Загрузка организаторов...
+    </div>
+  } @else {
+    <ul class="org-list">
+      <!-- Primary organizer (author) -->
+      @if (primaryOrganizer; as author) {
+        <li class="org-card org-card-author">
+          <div class="org-row">
+            <div class="org-info">
+              <span class="org-name">{{ getPlayerName(author) }}</span>
+              <span class="badge badge-author">автор</span>
+            </div>
+          </div>
+          <div class="org-perms-readonly">
+            @for (p of permissionLabels; track p.key) {
+              <span class="perm-chip perm-on"><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.check"/> {{ p.label }}</span>
+            }
+          </div>
+        </li>
+      }
+
+      <!-- Secondary organizers -->
+      @for (org of secondaryOrganizers; track org.org_id) {
+        <li class="org-card">
+          <div class="org-row">
+            <div class="org-info">
+              <span class="org-name">{{ getPlayerName(org) }}</span>
+            </div>
+            <div class="org-actions">
+              <button
+                type="button"
+                class="ghost-button icon danger"
+                title="Удалить организатора"
+                [disabled]="isBusy(org)"
+                (click)="removeOrganizer(org)"
+              ><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.remove"/></button>
+            </div>
+          </div>
+          <div class="org-perms">
+            @for (p of permissionLabels; track p.key) {
+              <label class="perm-toggle-label">
+                <input
+                  type="checkbox"
+                  [checked]="getPermission(org, p.key)"
+                  [disabled]="isBusy(org)"
+                  (change)="togglePermission(org, p.key, $any($event).target.checked)"
+                />
+                {{ p.label }}
+              </label>
+            }
+          </div>
+        </li>
+      }
+    </ul>
+
+    @if (secondaryOrganizers.length === 0) {
+      <p class="empty-note">Дополнительных организаторов пока нет.</p>
+    }
+
+    <!-- Add organizer via search -->
+    <div class="add-org">
+      <h3>Добавить организатора</h3>
+      <div class="search-wrap">
+        <div class="search-input-row">
+          <input
+            type="text"
+            class="search-input"
+            placeholder="Имя пользователя..."
+            [ngModel]="searchQuery"
+            (ngModelChange)="onSearchQueryChange($event)"
+            name="orgSearch"
+            autocomplete="off"
+          />
+          @if (isSearching) {
+            <span class="search-spinner" aria-label="Поиск..."><span class="loading-spinner"></span></span>
+          }
+        </div>
+
+        @if (searchResults.length > 0 && !selectedPlayer) {
+          <ul class="search-results">
+            @for (player of searchResults; track player.id) {
+              <li>
+                <button type="button" class="search-result-btn" (click)="selectPlayer(player)">
+                  {{ player.name_mention }}
+                </button>
+              </li>
+            }
+          </ul>
+        }
+      </div>
+
+      @if (selectedPlayer) {
+        <div class="selected-player-card">
+          <span>Выбран: <strong>{{ selectedPlayer.name_mention }}</strong></span>
+          <button type="button" class="btn-clear" (click)="clearSelectedPlayer()" aria-label="Отменить выбор"><mat-icon class="app-icon-inline" [svgIcon]="AppIcon.close"/></button>
+        </div>
+
+        <button type="button" class="primary" [disabled]="isAdding" (click)="addOrganizer()">
+          {{ isAdding ? "Добавление..." : "Добавить в организаторы" }}
+        </button>
+      }
+    </div>
+  }
+</div>

--- a/src/app/constructor/organizers-editor.component.scss
+++ b/src/app/constructor/organizers-editor.component.scss
@@ -1,0 +1,280 @@
+@use "../../styles/component-mixins" as cm;
+
+.organizers-block {
+  @include cm.surface-card(14px, 1rem);
+  margin: 1rem 0;
+}
+
+.block-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+
+  h2 {
+    margin: 0;
+    font-size: 1.1rem;
+  }
+}
+
+.hint-note {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: var(--app-muted-text);
+}
+
+.empty-note {
+  margin: 0.5rem 0 0.75rem;
+  font-size: 0.88rem;
+  color: var(--tg-theme-hint-color, #6b7280);
+}
+
+// ── Organizer list ───────────────────────────────────────────────────────────
+
+.org-list {
+  list-style: none;
+  margin: 0 0 0.75rem;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.org-card {
+  border: 1px solid var(--app-border);
+  border-radius: 10px;
+  padding: 0.65rem 0.8rem;
+  background: var(--app-surface);
+}
+
+.org-card-author {
+  border-color: rgba(234, 179, 8, 0.4);
+  background: rgba(234, 179, 8, 0.06);
+}
+
+.org-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.org-info {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+.org-name {
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.org-actions {
+  display: flex;
+  gap: 0.4rem;
+  flex-shrink: 0;
+}
+
+.org-perms {
+  margin-top: 0.55rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem 0.9rem;
+}
+
+.org-perms-readonly {
+  margin-top: 0.55rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+
+.perm-toggle-label {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.88rem;
+  cursor: pointer;
+
+  input:disabled {
+    cursor: wait;
+  }
+}
+
+// ── Badges & chips ───────────────────────────────────────────────────────────
+
+.badge {
+  display: inline-block;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+}
+
+.badge-author {
+  background: rgba(234, 179, 8, 0.15);
+  color: #92400e;
+  border: 1px solid rgba(234, 179, 8, 0.4);
+}
+
+.perm-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.2rem;
+  padding: 0.1rem 0.4rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+}
+
+.perm-on {
+  background: rgba(34, 197, 94, 0.12);
+  color: #166534;
+  border: 1px solid rgba(34, 197, 94, 0.35);
+}
+
+// ── Add organizer ────────────────────────────────────────────────────────────
+
+.add-org {
+  border-top: 1px solid var(--app-border);
+  padding-top: 0.85rem;
+
+  h3 {
+    margin: 0 0 0.6rem;
+    font-size: 0.95rem;
+  }
+}
+
+.search-wrap {
+  position: relative;
+  margin-bottom: 0.75rem;
+}
+
+.search-input-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.search-input {
+  @include cm.input-control();
+  flex: 1;
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.search-spinner {
+  display: inline-flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.search-results {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  list-style: none;
+  margin: 0;
+  padding: 0.3rem 0;
+  background: var(--app-surface);
+  border: 1px solid var(--app-border);
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+  z-index: 10;
+  max-height: 240px;
+  overflow-y: auto;
+}
+
+.search-result-btn {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: none;
+  padding: 0.5rem 0.85rem;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--app-text);
+
+  &:hover {
+    background: rgba(15, 23, 42, 0.06);
+  }
+}
+
+.selected-player-card {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.55rem 0.75rem;
+  background: rgba(99, 102, 241, 0.07);
+  border: 1px solid rgba(99, 102, 241, 0.3);
+  border-radius: 10px;
+  margin-bottom: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.btn-clear {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.9rem;
+  color: var(--tg-theme-hint-color, #6b7280);
+  padding: 0.2rem 0.4rem;
+  border-radius: 6px;
+  line-height: 1;
+
+  &:hover {
+    background: rgba(15, 23, 42, 0.07);
+  }
+}
+
+// ── Buttons ──────────────────────────────────────────────────────────────────
+
+.primary {
+  @include cm.button-base();
+  background: var(--app-accent);
+  color: var(--app-accent-contrast);
+  font-size: 0.9rem;
+
+  &:disabled {
+    opacity: 0.7;
+    cursor: wait;
+  }
+}
+
+.ghost-button {
+  @include cm.button-base();
+  background: transparent;
+  color: var(--app-text);
+  border: 1px solid var(--app-border);
+  font-size: 0.9rem;
+
+  &:hover:not(:disabled) {
+    background: rgba(15, 23, 42, 0.06);
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: wait;
+  }
+
+  &.icon {
+    padding: 0.3rem 0.45rem;
+    line-height: 1;
+  }
+
+  &.danger {
+    color: #b91c1c;
+    border-color: rgba(239, 68, 68, 0.35);
+
+    &:hover:not(:disabled) {
+      background: rgba(239, 68, 68, 0.1);
+    }
+  }
+}

--- a/src/app/constructor/organizers-editor.component.ts
+++ b/src/app/constructor/organizers-editor.component.ts
@@ -1,0 +1,232 @@
+import {Component, Input, OnDestroy, OnInit} from "@angular/core";
+import {FormsModule} from "@angular/forms";
+import {finalize} from "rxjs";
+import {MatIcon} from "@angular/material/icon";
+import {ConstructorService} from "./constructor.service";
+import {SnackbarService} from "../snackbar/snackbar.service";
+import {describeError} from "./constructor.models";
+import {AppIcon} from "../ui/icons";
+import {
+  GameOrganizer,
+  ORG_PERMISSION_LABELS,
+  OrgPermissionKey,
+  OrgPermissionLabel,
+  OrgPlayer,
+} from "./organizers.models";
+
+/**
+ * Manage the secondary organizers of a game: list them, invite new ones (via
+ * a player search, mirroring the team-invite flow), toggle their permissions
+ * and soft-remove them. All actions are author-only — the game editor only
+ * loads games the current user authors, so the controls are always shown.
+ */
+@Component({
+  selector: "app-organizers-editor",
+  standalone: true,
+  imports: [FormsModule, MatIcon],
+  templateUrl: "./organizers-editor.component.html",
+  styleUrl: "./organizers-editor.component.scss",
+})
+export class OrganizersEditorComponent implements OnInit, OnDestroy {
+  protected readonly AppIcon = AppIcon;
+  protected readonly permissionLabels: OrgPermissionLabel[] = ORG_PERMISSION_LABELS;
+
+  @Input({required: true}) gameId!: number;
+
+  isLoading = false;
+  organizers: GameOrganizer[] = [];
+
+  /** org_id currently being mutated (permission/delete), to disable its row. */
+  busyOrgId: number | null = null;
+
+  searchQuery = "";
+  searchResults: OrgPlayer[] = [];
+  isSearching = false;
+  selectedPlayer: OrgPlayer | null = null;
+  isAdding = false;
+
+  private searchTimer: ReturnType<typeof setTimeout> | undefined;
+
+  constructor(
+    private constructorService: ConstructorService,
+    private snackbar: SnackbarService,
+  ) {
+  }
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  ngOnDestroy(): void {
+    if (this.searchTimer) {
+      clearTimeout(this.searchTimer);
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Loading & derived lists
+  // -------------------------------------------------------------------------
+
+  load(): void {
+    this.isLoading = true;
+    this.constructorService.listOrganizers(this.gameId)
+      .pipe(finalize(() => { this.isLoading = false; }))
+      .subscribe({
+        next: page => { this.organizers = page.content ?? []; },
+        error: err => { this.snackbar.error(`Не удалось загрузить организаторов: ${describeError(err)}`); },
+      });
+  }
+
+  /** The primary organizer (game author), if present. `org_id == null`. */
+  get primaryOrganizer(): GameOrganizer | undefined {
+    return this.organizers.find(o => o.org_id === null);
+  }
+
+  /** Active secondary organizers — soft-deleted ones are hidden. */
+  get secondaryOrganizers(): GameOrganizer[] {
+    return this.organizers.filter(o => o.org_id !== null && !o.deleted);
+  }
+
+  isBusy(org: GameOrganizer): boolean {
+    return org.org_id !== null && this.busyOrgId === org.org_id;
+  }
+
+  getPlayerName(org: GameOrganizer): string {
+    return org.player?.name_mention ?? `#${org.player?.id}`;
+  }
+
+  getPermission(org: GameOrganizer, key: OrgPermissionKey): boolean {
+    return org[key];
+  }
+
+  // -------------------------------------------------------------------------
+  // Permission toggle
+  // -------------------------------------------------------------------------
+
+  togglePermission(org: GameOrganizer, key: OrgPermissionKey, value: boolean): void {
+    if (org.org_id === null) {
+      return;
+    }
+    const orgId = org.org_id;
+    this.busyOrgId = orgId;
+    this.constructorService.setOrganizerPermission(this.gameId, orgId, key, value)
+      .pipe(finalize(() => { this.busyOrgId = null; }))
+      .subscribe({
+        next: updated => { this.replaceOrg(updated); },
+        error: err => {
+          // The checkbox reflects the unconfirmed value — refresh from server.
+          this.load();
+          this.snackbar.error(`Не удалось изменить право: ${describeError(err)}`);
+        },
+      });
+  }
+
+  // -------------------------------------------------------------------------
+  // Remove (soft delete)
+  // -------------------------------------------------------------------------
+
+  removeOrganizer(org: GameOrganizer): void {
+    if (org.org_id === null) {
+      return;
+    }
+    if (!confirm(`Удалить организатора ${this.getPlayerName(org)}?`)) {
+      return;
+    }
+    const orgId = org.org_id;
+    this.busyOrgId = orgId;
+    this.constructorService.deleteOrganizer(this.gameId, orgId)
+      .pipe(finalize(() => { this.busyOrgId = null; }))
+      .subscribe({
+        next: updated => {
+          this.replaceOrg(updated);
+          this.snackbar.success(`${this.getPlayerName(org)} удалён из организаторов`);
+        },
+        error: err => { this.snackbar.error(`Не удалось удалить организатора: ${describeError(err)}`); },
+      });
+  }
+
+  // -------------------------------------------------------------------------
+  // Add (via search)
+  // -------------------------------------------------------------------------
+
+  onSearchQueryChange(query: string): void {
+    this.searchQuery = query;
+    if (this.searchTimer) {
+      clearTimeout(this.searchTimer);
+    }
+    if (!query.trim()) {
+      this.searchResults = [];
+      this.selectedPlayer = null;
+      return;
+    }
+    this.searchTimer = setTimeout(() => { this.performSearch(query.trim()); }, 350);
+  }
+
+  performSearch(query: string): void {
+    this.isSearching = true;
+    this.constructorService.searchPlayers(query)
+      .pipe(finalize(() => { this.isSearching = false; }))
+      .subscribe({
+        next: res => { this.searchResults = res.items; },
+        error: () => { this.snackbar.error("Не удалось найти игроков"); },
+      });
+  }
+
+  selectPlayer(player: OrgPlayer): void {
+    this.selectedPlayer = player;
+    this.searchQuery = player.name_mention;
+    this.searchResults = [];
+  }
+
+  clearSelectedPlayer(): void {
+    this.selectedPlayer = null;
+    this.searchQuery = "";
+    this.searchResults = [];
+  }
+
+  addOrganizer(): void {
+    if (!this.selectedPlayer) {
+      this.snackbar.error("Выберите игрока из списка");
+      return;
+    }
+    const player = this.selectedPlayer;
+    this.isAdding = true;
+    this.constructorService.addOrganizer(this.gameId, player.id)
+      .pipe(finalize(() => { this.isAdding = false; }))
+      .subscribe({
+        next: org => {
+          this.replaceOrg(org);
+          this.clearSelectedPlayer();
+          this.snackbar.success(`${this.getPlayerName(org)} добавлен в организаторы`);
+        },
+        error: err => {
+          const type = (err?.error as { type?: string } | null)?.type;
+          if (type === "PlayerAlreadyOrganizer") {
+            this.snackbar.error("Этот игрок уже является организатором игры");
+          } else if (type === "GameHasAnotherAuthor") {
+            this.snackbar.error("Управлять организаторами может только автор игры");
+          } else {
+            this.snackbar.error(`Не удалось добавить организатора: ${describeError(err)}`);
+          }
+        },
+      });
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------
+
+  /** Insert or replace an organizer by org_id, keeping the existing order. */
+  private replaceOrg(org: GameOrganizer): void {
+    const idx = this.organizers.findIndex(o => o.org_id === org.org_id);
+    if (idx >= 0) {
+      this.organizers = [
+        ...this.organizers.slice(0, idx),
+        org,
+        ...this.organizers.slice(idx + 1),
+      ];
+    } else {
+      this.organizers = [...this.organizers, org];
+    }
+  }
+}

--- a/src/app/constructor/organizers.models.ts
+++ b/src/app/constructor/organizers.models.ts
@@ -1,0 +1,66 @@
+// ---------------------------------------------------------------------------
+// Game organizers model — mirrors the "Game Organizers API" contract.
+// Endpoints live under /games/{id}/organizers. snake_case throughout so the
+// objects can be round-tripped between server responses and the UI.
+// ---------------------------------------------------------------------------
+
+/** Standard player projection used across the API. */
+export interface OrgPlayer {
+  id: number;
+  can_be_author: boolean;
+  name_mention: string;
+}
+
+/** The four independent organizer permission flags. */
+export interface OrgPermissions {
+  can_spy: boolean;
+  can_see_log_keys: boolean;
+  can_validate_waivers: boolean;
+  view_scenario: boolean;
+}
+
+export type OrgPermissionKey = keyof OrgPermissions;
+
+/**
+ * Shared response shape of every organizers endpoint.
+ * `org_id` is `null` for the primary organizer (the game's author), a number
+ * for secondary organizers. `deleted` marks a soft-removed secondary org.
+ */
+export interface GameOrganizer extends OrgPermissions {
+  org_id: number | null;
+  player: OrgPlayer;
+  deleted: boolean;
+}
+
+/** Body of `POST /games/{id}/organizers`. */
+export interface NewOrg {
+  player_id: number;
+}
+
+/** Body of `DELETE /games/{id}/organizers`. */
+export interface DeleteOrg {
+  org_id: number;
+}
+
+/** Body of `PUT /games/{id}/organizers/{org_id}`. */
+export interface OrgPermissionUpdate {
+  permission: OrgPermissionKey;
+  value: boolean;
+}
+
+export interface OrgPermissionLabel {
+  key: OrgPermissionKey;
+  label: string;
+}
+
+/** UI labels (ru) for each permission, in display order. */
+export const ORG_PERMISSION_LABELS: OrgPermissionLabel[] = [
+  {key: "can_spy", label: "Наблюдение за командами"},
+  {key: "can_see_log_keys", label: "Лог ключей"},
+  {key: "can_validate_waivers", label: "Проверка вейверов"},
+  {key: "view_scenario", label: "Просмотр сценария"},
+];
+
+/** The valid permission keys — used for client-side validation of the PUT. */
+export const ORG_PERMISSION_KEYS: OrgPermissionKey[] =
+  ORG_PERMISSION_LABELS.map(p => p.key);


### PR DESCRIPTION
## Summary

Adds an **Organizers** section to the game draft editor (`/games/constructor/:id`) so the game author can manage the game's organizers, per the new Game Organizers API contract.

The author can now:
- **See the organizers** — the primary organizer (author) is shown first with a badge and read-only "all permissions" chips; secondary organizers follow.
- **Add a new organizer** via a debounced player search, mirroring the existing team-invite flow (`captain-bridge`).
- **Change permissions** per organizer with toggles for `can_spy`, `can_see_log_keys`, `can_validate_waivers` and `view_scenario`.
- **Remove an organizer** (soft delete) with a confirmation prompt; soft-deleted orgs are hidden from the list.

## Implementation

- `organizers.models.ts` — types mirroring the contract (`GameOrganizer`, `OrgPlayer`, `OrgPermissions`, request bodies, permission labels).
- `ConstructorService` — new methods: `listOrganizers`, `addOrganizer`, `deleteOrganizer` (org passed in the request **body**, per the contract), `setOrganizerPermission`, and `searchPlayers`.
- `OrganizersEditorComponent` — standalone component handling the list, search/add, permission toggles and removal, embedded in `game-editor` via `[gameId]`.
- Error handling switches on the error envelope `type` (`PlayerAlreadyOrganizer`, `GameHasAnotherAuthor`) for friendly Russian messages; permission updates re-fetch on failure to keep the UI in sync.

## Notes
- Management actions are author-only; the editor only loads games the current user authors, so the controls are always shown there.
- A permission toggle sends one `PUT` per change and updates the row from the response, matching the contract's per-permission update endpoint.

## Verification
- `ng build` succeeds.

https://claude.ai/code/session_01Waj2e4AVmWpRdmE1WwBoVp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Waj2e4AVmWpRdmE1WwBoVp)_