### PR TITLE
Render newlines as line breaks in HTML hints

### DIFF
--- a/src/app/hint.part/hint.part.component.html
+++ b/src/app/hint.part/hint.part.component.html
@@ -1,7 +1,7 @@
 <div class="hint-part">
   @switch (hint.type) {
     @case (HintType.text) {
-      <p class="hint-text" [innerHTML]="hint.text"></p>
+      <p class="hint-text" [innerHTML]="toHtml(hint.text)"></p>
     }
     @case (HintType.gps) {
       <a [href]="'https://maps.yandex.ru/?ll=' + hint.longitude + ',' + hint.latitude + '&z=18'">
@@ -57,6 +57,6 @@
     }
   }
   @if (hint.caption) {
-    <p [innerHTML]="hint.caption"></p>
+    <p [innerHTML]="toHtml(hint.caption)"></p>
   }
 </div>

--- a/src/app/hint.part/hint.part.component.ts
+++ b/src/app/hint.part/hint.part.component.ts
@@ -17,4 +17,19 @@ export class HintPartComponent {
 
     protected readonly HintType = HintType;
     protected readonly JSON = JSON;
+
+  /**
+   * Prepares an HTML hint for rendering: normalizes line endings and turns
+   * text line breaks into <br>. Newlines that sit inside a tag (e.g. between
+   * attributes) are left untouched so the markup is not broken.
+   */
+  toHtml(value: string | undefined | null): string {
+    if (!value) {
+      return '';
+    }
+
+    return value
+      .replace(/\r\n?/g, '\n')
+      .replace(/\n(?![^<]*>)/g, '<br>');
+  }
 }


### PR DESCRIPTION
## Summary

HTML hint text/captions previously rendered `\n` line separators as collapsed whitespace. This converts text line breaks into `<br>` before rendering.

All hint HTML (last games, current game hints, org scenario, typed-key effects, game-event effects) funnels through `app-hint-part`, so the conversion lives in one place: `HintPartComponent.toHtml()`, applied to both `hint.text` and `hint.caption`.

## Safety of the conversion

Blindly replacing every `\n` with `<br>` is **not** safe in all HTML contexts — a newline *inside* a tag (e.g. between attributes, `<a href="…"\n title="…">`) would break the markup. To guard against that, the replacement only targets newlines that are not inside a tag:

```ts
value.replace(/\r\n?/g, '\n').replace(/\n(?[^<]*>)/g, '<br>')
```

The negative lookahead `(?[^<]*>)` skips any `\n` that is followed by a run of non-`<` characters ending in `>` (i.e. the newline is sitting inside an open tag), and `\r\n?` first normalizes CRLF/CR line endings.

## Test

- `ng build --configuration development` succeeds.

https://claude.ai/code/session_01YEvw4gR3YyBgxCRPppU9bm

---
_Generated by [Claude Code](https://claude.ai/code/session_01YEvw4gR3YyBgxCRPppU9bm)_